### PR TITLE
fix: preserve reader preferences across app updates

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -29,6 +29,7 @@ This is the active completion and validation checklist. Historical completed wor
 - [ ] Select the next user-directed roadmap or issue item before implementation.
 - [ ] Keep MOBI, AZW, AZW3, and FB2 explicitly unsupported unless the user approves a conversion/support plan.
 - [ ] Treat broader offline RAR/7z extraction and optional device matrices as separately scoped follow-up.
+- [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 
 ## Verification handoff
 

--- a/app/src/main/java/com/vangeaux/lagrange/LibraryReaderPreferences.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/LibraryReaderPreferences.kt
@@ -37,6 +37,9 @@ internal val EPUB_ACCESSIBILITY_FONT_FAMILY_OPTIONS = listOf(
 internal const val DEFAULT_READER_PAGE_GAP_DP = 16f
 internal const val MAX_READER_PAGE_GAP_DP = 48f
 
+private const val READER_PREFERENCES_STORAGE_VERSION = 1
+private const val READER_PREFERENCES_PROFILES_KEY = "profiles"
+
 data class LibraryReaderPreferences(
     val readingDirection: LibraryReadingDirection = LibraryReadingDirection.LEFT_TO_RIGHT,
     val theme: EpubReaderTheme = EpubReaderTheme.Sepia,
@@ -108,38 +111,46 @@ internal fun epubReaderFontFamilyFromStorage(value: String?): EpubReaderFontFami
 internal fun libraryReaderPreferencesStorageValue(
     values: Map<String, LibraryReaderPreferences>
 ): String = JSONObject().apply {
-    values.toSortedMap().forEach { (libraryId, rawValue) ->
-        if (libraryId.isBlank()) return@forEach
-        val value = rawValue.normalized()
-        put(libraryId, JSONObject().apply {
-            put("readingDirection", libraryReadingDirectionStorageValue(value.readingDirection))
-            put("theme", epubReaderThemeStorageValue(value.theme))
-            put("fontFamily", epubReaderFontFamilyStorageValue(value.fontFamily))
-            value.customFont?.let { put("customFont", customFontStorageValue(it)) }
-            put("fontScale", value.fontScale.toDouble())
-            put("top", value.padding.top.toDouble())
-            put("bottom", value.padding.bottom.toDouble())
-            put("left", value.padding.left.toDouble())
-            put("right", value.padding.right.toDouble())
-            put("epubLayout", readerLayoutModeStorageValue(value.epubLayoutMode))
-            put("pdfLayout", readerLayoutModeStorageValue(value.pdfLayoutMode))
-            put("pdfPageGapDp", value.pdfPageGapDp.toDouble())
-            put("comicLayout", readerLayoutModeStorageValue(value.comicLayoutMode))
-            put("comicPageGapDp", value.comicPageGapDp.toDouble())
-        })
-    }
+    put("version", READER_PREFERENCES_STORAGE_VERSION)
+    put(READER_PREFERENCES_PROFILES_KEY, JSONObject().apply {
+        values.toSortedMap().forEach { (libraryId, rawValue) ->
+            if (libraryId.isBlank()) return@forEach
+            val value = rawValue.normalized()
+            put(libraryId, libraryReaderPreferenceStorageValue(value))
+        }
+    })
 }.toString()
+
+private fun libraryReaderPreferenceStorageValue(value: LibraryReaderPreferences): JSONObject =
+    value.normalized().let { normalized ->
+        JSONObject().apply {
+            put("readingDirection", libraryReadingDirectionStorageValue(normalized.readingDirection))
+            put("theme", epubReaderThemeStorageValue(normalized.theme))
+            put("fontFamily", epubReaderFontFamilyStorageValue(normalized.fontFamily))
+            normalized.customFont?.let { put("customFont", customFontStorageValue(it)) }
+            put("fontScale", normalized.fontScale.toDouble())
+            put("top", normalized.padding.top.toDouble())
+            put("bottom", normalized.padding.bottom.toDouble())
+            put("left", normalized.padding.left.toDouble())
+            put("right", normalized.padding.right.toDouble())
+            put("epubLayout", readerLayoutModeStorageValue(normalized.epubLayoutMode))
+            put("pdfLayout", readerLayoutModeStorageValue(normalized.pdfLayoutMode))
+            put("pdfPageGapDp", normalized.pdfPageGapDp.toDouble())
+            put("comicLayout", readerLayoutModeStorageValue(normalized.comicLayoutMode))
+            put("comicPageGapDp", normalized.comicPageGapDp.toDouble())
+        }
+    }
 
 internal fun libraryReaderPreferencesFromStorage(value: String?): Map<String, LibraryReaderPreferences> {
     if (value.isNullOrBlank()) return emptyMap()
     return runCatching {
         val root = JSONObject(value)
+        val profiles = root.optJSONObject(READER_PREFERENCES_PROFILES_KEY) ?: root
         buildMap {
-            root.keys().forEach { libraryId ->
+            profiles.keys().forEach { libraryId ->
                 if (libraryId.isBlank()) return@forEach
-                val item = root.optJSONObject(libraryId) ?: return@forEach
-                put(
-                    libraryId,
+                val item = profiles.optJSONObject(libraryId) ?: return@forEach
+                runCatching {
                     LibraryReaderPreferences(
                         readingDirection = libraryReadingDirectionFromStorage(item.optString("readingDirection")),
                         theme = epubReaderThemeFromStorage(item.optString("theme")),
@@ -173,7 +184,7 @@ internal fun libraryReaderPreferencesFromStorage(value: String?): Map<String, Li
                             DEFAULT_READER_PAGE_GAP_DP.toDouble()
                         ).toFloat()
                     ).normalized()
-                )
+                }.getOrNull()?.let { decoded -> put(libraryId, decoded) }
             }
         }
     }.getOrDefault(emptyMap())

--- a/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
@@ -4,11 +4,54 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 import org.readium.r2.navigator.preferences.Axis
 import org.readium.r2.navigator.preferences.ReadingProgression
 import java.io.File
 
 class LibraryReaderPreferencesTest {
+    @Test
+    fun `reader profile storage uses a versioned envelope`() {
+        val profile = LibraryReaderPreferences(
+            readingDirection = LibraryReadingDirection.RIGHT_TO_LEFT,
+            theme = EpubReaderTheme.Dark,
+            fontFamily = EpubReaderFontFamily.OPEN_DYSLEXIC,
+            fontScale = 1.3f,
+            padding = EpubPaddingPercentages(10f, 20f, 30f, 40f),
+            epubLayoutMode = ReaderLayoutMode.CONTINUOUS,
+            pdfLayoutMode = ReaderLayoutMode.PAGINATED,
+            pdfPageGapDp = 8f,
+            comicLayoutMode = ReaderLayoutMode.CONTINUOUS,
+            comicPageGapDp = 24f
+        )
+
+        val storage = JSONObject(libraryReaderPreferencesStorageValue(mapOf("library" to profile)))
+
+        assertTrue(storage.has("version"))
+        assertTrue(storage.has("profiles"))
+        assertEquals(profile, libraryReaderPreferencesFromStorage(storage.toString())["library"])
+    }
+
+    @Test
+    fun `malformed profile does not erase valid profiles`() {
+        val storage = JSONObject().apply {
+            put("version", 1)
+            put("profiles", JSONObject().apply {
+                put("valid", JSONObject().apply {
+                    put("theme", "dark")
+                    put("fontFamily", "system_sans_serif")
+                })
+                put("malformed", "not-an-object")
+            })
+        }
+
+        val decoded = libraryReaderPreferencesFromStorage(storage.toString())
+
+        assertEquals(EpubReaderTheme.Dark, decoded.getValue("valid").theme)
+        assertEquals(EpubReaderFontFamily.SYSTEM_SANS_SERIF, decoded.getValue("valid").fontFamily)
+        assertFalse(decoded.containsKey("malformed"))
+    }
+
     @Test
     fun `library reader profiles round trip independently`() {
         val novels = LibraryReaderPreferences(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Lagrange is a native Android client for BookOrbit focused on reading, listening,
 
 - Keep foreground audiobook playback service-owned and compact-only unless a user-approved product decision changes that boundary.
 - Preserve exact BookOrbit statuses independently from legacy completion flags.
-- Preserve per-library reader profiles, cover ownership/aspect ratios, and reader-direction behavior.
+- Preserve per-library reader profiles, cover ownership/aspect ratios, and reader-direction behavior. Reader profiles use a versioned, per-library JSON envelope; legacy flat profiles remain readable, and malformed profiles do not invalidate other libraries.
 - Bound source responses, decoded image sizes, cache scope, and reader preparation; clean incomplete temporary outputs.
 - Keep authentication-origin, TLS, cookie, token, and redirect checks separate from general URL helpers.
 - Do not route connected standalone audio through Readium publication retrieval.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,7 @@ This document contains the current project direction only. Historical work order
 3. Keep native AppAuth/Custom Tabs deferred until BookOrbit provides deployed mobile-redirect allow-list support and the identity-provider callback is registered. The interim server-hosted sign-in WebView is implemented.
 4. Consider additional format support only through a new user-approved work item; MOBI, AZW, AZW3, and FB2 remain unsupported.
 5. Treat broader offline RAR/7z extraction and other optional validation as user-directed follow-up, not an implementation blocker for the current release.
+6. [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 
 ## Decision and documentation rules
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,9 @@ When the affected scope requires it, verify:
 - EPUB resume and continuous-mode active-resource seeking;
 - PDF/comic page navigation and progress;
 - audiobook compact-player restoration, seeking, chapters, and speed;
-- reader settings persistence per library;
+- reader settings persistence per library; issue #19 current-package APK-upgrade persistence was user-confirmed working on the supplied debug build;
+- same-application-ID APK upgrade preserves EPUB theme/font/size/margins and the applicable PDF/comic direction, layout, and page-gap settings for more than one library;
+- the reader preference store accepts legacy flat profiles and preserves valid profiles when another stored profile is malformed; migration from the retired `com.bookorbit.android` package is intentionally out of scope;
 - server-missing versus locally deleted state;
 - large text, accessibility, orientation, offline, and narrow-width behavior.
 


### PR DESCRIPTION
## Summary
- Store per-library reader preferences in a versioned JSON envelope.
- Continue decoding legacy flat profiles for current-package upgrades.
- Isolate malformed profiles so valid libraries retain their settings.
- Document the persistence boundary and approved exclusion of the retired package migration.

## Verification
- Focused `LibraryReaderPreferencesTest` passed through ad-hoc verification.
- JVM unit suite: 386 tests, 0 failures, 0 errors, 0 skipped.
- `lintDebug` passed.
- `compileDebugAndroidTestKotlin` passed.
- `assembleDebug` and `assembleDebugAndroidTest` passed.
- User confirmed the supplied debug build works.
- No ADB device was connected; instrumentation was compiled but not executed.

Closes #19
