### PR TITLE
fix: keep EPUB direction changes out of text layout

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -29,6 +29,7 @@ This is the active completion and validation checklist. Historical completed wor
 - [ ] Select the next user-directed roadmap or issue item before implementation.
 - [ ] Keep MOBI, AZW, AZW3, and FB2 explicitly unsupported unless the user approves a conversion/support plan.
 - [ ] Treat broader offline RAR/7z extraction and optional device matrices as separately scoped follow-up.
+- [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
 - [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 
 ## Verification handoff

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
@@ -99,14 +99,15 @@ internal suspend fun openReadiumEpub(
     ReadiumEpubOpenResult.Opened(publication)
 }
 
-internal fun readiumReadingProgression(
+internal fun readiumEpubReadingProgression(
     readingDirection: LibraryReadingDirection
-): ReadiumReadingProgression = if (
-    readingDirection == LibraryReadingDirection.RIGHT_TO_LEFT
-) {
-    ReadiumReadingProgression.RTL
-} else {
-    ReadiumReadingProgression.LTR
+): ReadiumReadingProgression {
+    // LibraryReadingDirection controls physical tap navigation only. Keep EPUB
+    // content/layout direction unchanged so Readium does not alter typography.
+    return when (readingDirection) {
+        LibraryReadingDirection.LEFT_TO_RIGHT,
+        LibraryReadingDirection.RIGHT_TO_LEFT -> ReadiumReadingProgression.LTR
+    }
 }
 
 @OptIn(ExperimentalReadiumApi::class)
@@ -137,7 +138,7 @@ internal fun readiumPreferences(
     },
     fontSize = fontScale.coerceIn(0.9f, 1.5f).toDouble(),
     fontFamily = readiumFontFamily(fontFamily),
-    readingProgression = readiumReadingProgression(readingDirection),
+    readingProgression = readiumEpubReadingProgression(readingDirection),
     pageMargins = 0.0,
     columnCount = ColumnCount.ONE,
     scroll = layoutMode == ReaderLayoutMode.CONTINUOUS

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumPdfReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumPdfReaderActivity.kt
@@ -45,6 +45,7 @@ import org.readium.r2.navigator.input.InputListener
 import org.readium.r2.navigator.input.TapEvent
 import org.readium.r2.navigator.pdf.PdfNavigatorFragment
 import org.readium.r2.navigator.preferences.Axis
+import org.readium.r2.navigator.preferences.ReadingProgression as ReadiumReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -100,6 +101,16 @@ internal data class ReadiumPdfProgressResult(
     val pageCount: Int,
     val percent: Float?
 )
+
+internal fun readiumReadingProgression(
+    readingDirection: LibraryReadingDirection
+): ReadiumReadingProgression = if (
+    readingDirection == LibraryReadingDirection.RIGHT_TO_LEFT
+) {
+    ReadiumReadingProgression.RTL
+} else {
+    ReadiumReadingProgression.LTR
+}
 
 internal fun pdfiumPreferencesFor(
     preferences: LibraryReaderPreferences

--- a/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
@@ -160,14 +160,14 @@ class LibraryReaderPreferencesTest {
     }
 
     @Test
-    fun `EPUB preferences apply the library reading progression`() {
+    fun `EPUB preferences keep layout progression left to right for both tap directions`() {
         assertEquals(
             ReadingProgression.LTR,
-            readiumReadingProgression(LibraryReadingDirection.LEFT_TO_RIGHT)
+            readiumEpubReadingProgression(LibraryReadingDirection.LEFT_TO_RIGHT)
         )
         assertEquals(
-            ReadingProgression.RTL,
-            readiumReadingProgression(LibraryReadingDirection.RIGHT_TO_LEFT)
+            ReadingProgression.LTR,
+            readiumEpubReadingProgression(LibraryReadingDirection.RIGHT_TO_LEFT)
         )
     }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,7 @@ This document contains the current project direction only. Historical work order
 4. Consider additional format support only through a new user-approved work item; MOBI, AZW, AZW3, and FB2 remain unsupported.
 5. Treat broader offline RAR/7z extraction and other optional validation as user-directed follow-up, not an implementation blocker for the current release.
 6. [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
+7. [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
 
 ## Decision and documentation rules
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -60,6 +60,7 @@ When the affected scope requires it, verify:
 
 - normal and Preview launch isolation;
 - EPUB resume and continuous-mode active-resource seeking;
+- EPUB reading-direction changes preserve text alignment, punctuation, and other typography/layout settings while only reversing left/right edge tap navigation; verify both directions in paginated and continuous modes. User-confirmed on the rebuilt debug APK;
 - PDF/comic page navigation and progress;
 - audiobook compact-player restoration, seeking, chapters, and speed;
 - reader settings persistence per library; issue #19 current-package APK-upgrade persistence was user-confirmed working on the supplied debug build;


### PR DESCRIPTION
## Summary
- Keep EPUB text/layout progression LTR regardless of tap-navigation direction.
- Preserve left/right tap navigation switching for the reader direction preference.
- Keep PDF direction behavior unchanged.
- Update focused tests and validation documentation.

## Verification
- `./gradlew --no-daemon --console=plain :app:testDebugUnitTest --tests com.vangeaux.lagrange.LibraryReaderPreferencesTest`
- Full debug compile, unit/instrumentation compile, unit tests, lint, and debug APK assembly passed.
- User-confirmed behavior on the rebuilt debug APK.

Closes #24