### PR TITLE
feat: adjustable reader options and EPUB line spacing

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -30,6 +30,7 @@ This is the active completion and validation checklist. Historical completed wor
 - [ ] Keep MOBI, AZW, AZW3, and FB2 explicitly unsupported unless the user approves a conversion/support plan.
 - [ ] Treat broader offline RAR/7z extraction and optional device matrices as separately scoped follow-up.
 - [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
+- [x] [#23](https://github.com/van-geaux/lagrange-reader/issues/23): make the reading-options window adjustable for live preview, with a default height of approximately two-thirds of the screen so the reader remains visible while settings are changed; include the already requested persisted EPUB line-spacing option. Automated coverage and user-confirmed on-device validation are complete.
 - [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 
 ## Verification handoff

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -29,6 +29,7 @@ This is the active completion and validation checklist. Historical completed wor
 - [ ] Select the next user-directed roadmap or issue item before implementation.
 - [ ] Keep MOBI, AZW, AZW3, and FB2 explicitly unsupported unless the user approves a conversion/support plan.
 - [ ] Treat broader offline RAR/7z extraction and optional device matrices as separately scoped follow-up.
+- [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
 - [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 
 ## Verification handoff

--- a/app/src/androidTest/java/com/vangeaux/lagrange/EpubReaderOptionsOverlayInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/vangeaux/lagrange/EpubReaderOptionsOverlayInstrumentedTest.kt
@@ -2,10 +2,13 @@ package com.vangeaux.lagrange
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -15,13 +18,63 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
 class EpubReaderOptionsOverlayInstrumentedTest {
     @get:Rule
     val composeRule = createComposeRule()
+
+    @Test
+    fun readiumPreferencesEnableUserCssOverridesForLineSpacing() {
+        val preferences = readiumPreferences(
+            theme = EpubReaderTheme.Light,
+            fontScale = 1.0f,
+            lineSpacing = 1.4f
+        )
+
+        assertEquals(1.4, preferences.lineHeight)
+        assertFalse(preferences.publisherStyles == true)
+    }
+
+    @Test
+    fun readerOptionsSheetDefaultsToTwoThirdsAndCanExpand() {
+        composeRule.setContent {
+            Box(modifier = Modifier.size(width = 360.dp, height = 600.dp)) {
+                EpubReaderOptionsBottomSheet(
+                    title = "Resize test",
+                    status = "Chapter 1/1 · Page 1/1",
+                    preferences = LibraryReaderPreferences(),
+                    onContinueReading = {},
+                    onCloseBook = {},
+                    onPreferencesChange = {},
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("reader-options-sheet").assertIsDisplayed()
+
+        composeRule.onNodeWithText("Reading configuration")
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag("reader-options-resize-handle")
+            .assertIsDisplayed()
+            .assertHeightIsAtLeast(READER_OPTIONS_RESIZE_HANDLE_MIN_HEIGHT_DP.dp)
+
+        composeRule
+            .onNodeWithTag("reader-options-resize-handle")
+            .performTouchInput { swipeUp() }
+
+        composeRule.onNodeWithTag("reader-options-sheet").assertIsDisplayed()
+    }
 
     @Test
     fun bottomSheetSeparatesContinueReadingFromClosingTheBook() {
@@ -97,6 +150,7 @@ class EpubReaderOptionsOverlayInstrumentedTest {
             LibraryReaderPreferences(
                 theme = EpubReaderTheme.Dark,
                 fontScale = 1.3f,
+                lineSpacing = 1.2f,
                 readingDirection = LibraryReadingDirection.RIGHT_TO_LEFT,
                 epubLayoutMode = ReaderLayoutMode.CONTINUOUS,
                 padding = EpubPaddingPercentages(11f, 22f, 33f, 44f)
@@ -122,11 +176,16 @@ class EpubReaderOptionsOverlayInstrumentedTest {
         composeRule.onNodeWithTag("reader-options-reading-font-family-system_sans_serif")
             .performScrollTo()
             .performClick()
+        composeRule
+            .onNodeWithTag("reader-options-reading-line-spacing")
+            .performScrollTo()
+            .performTouchInput { swipeRight() }
 
         composeRule.runOnIdle {
             assertEquals(EpubReaderFontFamily.SYSTEM_SANS_SERIF, profile.value.fontFamily)
             assertEquals(EpubReaderTheme.Dark, profile.value.theme)
             assertEquals(1.3f, profile.value.fontScale)
+            assertTrue(profile.value.lineSpacing > 1.2f)
             assertEquals(LibraryReadingDirection.RIGHT_TO_LEFT, profile.value.readingDirection)
             assertEquals(ReaderLayoutMode.CONTINUOUS, profile.value.epubLayoutMode)
             assertEquals(EpubPaddingPercentages(11f, 22f, 33f, 44f), profile.value.padding)

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -109,6 +110,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -1646,6 +1648,20 @@ internal fun readerChromeProgressionState(
 internal const val READER_TAP_ZONE_TUTORIAL_DURATION_MILLIS = 3_000L
 internal const val READER_TAP_ZONE_TUTORIAL_LABEL_FONT_SIZE_SP = 28
 internal const val READER_POSITION_CONTROL_HEIGHT_FRACTION = 0.75f
+internal const val READER_OPTIONS_DEFAULT_HEIGHT_FRACTION = 2f / 3f
+internal const val READER_OPTIONS_MIN_HEIGHT_FRACTION = 0.45f
+internal const val READER_OPTIONS_MAX_HEIGHT_FRACTION = 0.92f
+internal const val READER_OPTIONS_RESIZE_HANDLE_MIN_HEIGHT_DP = 48
+
+internal fun readerOptionsHeightFractionAfterDrag(
+    currentFraction: Float,
+    dragAmountPx: Float,
+    containerHeightPx: Float
+): Float {
+    if (!containerHeightPx.isFinite() || containerHeightPx <= 0f) return currentFraction
+    return (currentFraction - dragAmountPx / containerHeightPx)
+        .coerceIn(READER_OPTIONS_MIN_HEIGHT_FRACTION, READER_OPTIONS_MAX_HEIGHT_FRACTION)
+}
 
 internal data class ReaderTapZoneTutorialRegion(
     val label: String,
@@ -2190,84 +2206,112 @@ internal fun EpubReaderOptionsBottomSheet(
             )
         }
     }
-    MaterialTheme(
-        colorScheme = colors,
-        typography = parentTypography,
-        shapes = parentShapes
-    ) {
-        Surface(
-            modifier = modifier,
-            shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-            color = MaterialTheme.colorScheme.surface,
-            contentColor = MaterialTheme.colorScheme.onSurface,
-            shadowElevation = 12.dp
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        var sheetHeightFraction by remember { mutableStateOf(READER_OPTIONS_DEFAULT_HEIGHT_FRACTION) }
+        val density = LocalDensity.current
+        val containerHeightPx = with(density) { maxHeight.toPx() }
+        val sheetHeight = maxHeight * sheetHeightFraction
+        MaterialTheme(
+            colorScheme = colors,
+            typography = parentTypography,
+            shapes = parentShapes
         ) {
-            Column(
+            Surface(
                 modifier = Modifier
-                    .heightIn(max = 620.dp)
-                    .verticalScroll(rememberScrollState())
-                    .padding(
-                        start = 20.dp,
-                        top = 10.dp,
-                        end = 20.dp,
-                        bottom = 18.dp + EPUB_READER_PROGRESS_FOOTER_HEIGHT
-                    ),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                    .fillMaxWidth()
+                    .height(sheetHeight)
+                    .testTag("reader-options-sheet"),
+                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                shadowElevation = 12.dp
             ) {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Column(
+                    modifier = Modifier.fillMaxHeight()
+                ) {
                     Box(
                         modifier = Modifier
-                            .size(width = 42.dp, height = 4.dp)
-                            .background(
-                                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.65f),
-                                shape = RoundedCornerShape(2.dp)
+                            .fillMaxWidth()
+                            .heightIn(min = READER_OPTIONS_RESIZE_HANDLE_MIN_HEIGHT_DP.dp)
+                            .padding(horizontal = 20.dp)
+                            .pointerInput(containerHeightPx) {
+                                detectVerticalDragGestures { _, dragAmount ->
+                                    sheetHeightFraction = readerOptionsHeightFractionAfterDrag(
+                                        currentFraction = sheetHeightFraction,
+                                        dragAmountPx = dragAmount,
+                                        containerHeightPx = containerHeightPx
+                                    )
+                                }
+                            }
+                            .testTag("reader-options-resize-handle"),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(width = 42.dp, height = 4.dp)
+                                .background(
+                                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.65f),
+                                    shape = RoundedCornerShape(2.dp)
+                                )
+                        )
+                    }
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .verticalScroll(rememberScrollState())
+                            .padding(
+                                start = 20.dp,
+                                end = 20.dp,
+                                bottom = 18.dp + EPUB_READER_PROGRESS_FOOTER_HEIGHT
+                            ),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                "Reader options",
+                                modifier = Modifier.semantics { heading() },
+                                style = MaterialTheme.typography.titleLarge
                             )
-                    )
-                }
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        "Reader options",
-                        modifier = Modifier.semantics { heading() },
-                        style = MaterialTheme.typography.titleLarge
-                    )
-                    Text(
-                        title,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        status,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    Button(
-                        onClick = onContinueReading,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text("Continue reading")
+                            Text(
+                                title,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                status,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Button(
+                                onClick = onContinueReading,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text("Continue reading")
+                            }
+                            OutlinedButton(
+                                onClick = onCloseBook,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text("Close book")
+                            }
+                        }
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.45f))
+                        Text("Reading configuration", style = MaterialTheme.typography.titleMedium)
+                        ReaderConfigurationControls(
+                            value = preferences,
+                            onPreferencesChange = onPreferencesChange,
+                            isEpub = true,
+                            onCustomFontRequest = onCustomFontRequest,
+                            onCustomFontRemove = onCustomFontRemove
+                        )
                     }
-                    OutlinedButton(
-                        onClick = onCloseBook,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text("Close book")
-                    }
                 }
-                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.45f))
-                Text("Reading configuration", style = MaterialTheme.typography.titleMedium)
-                ReaderConfigurationControls(
-                    value = preferences,
-                    onPreferencesChange = onPreferencesChange,
-                    isEpub = true,
-                    onCustomFontRequest = onCustomFontRequest,
-                    onCustomFontRemove = onCustomFontRemove
-                )
             }
         }
     }
@@ -2913,6 +2957,10 @@ internal fun epubPageJumpJavascript(pageIndex: Int): String {
 
 internal fun formatEpubFontScale(fontScale: Float): String {
     return String.format(Locale.US, "%.0f%%", fontScale * 100f)
+}
+
+internal fun formatEpubLineSpacing(lineSpacing: Float): String {
+    return String.format(Locale.US, "%.1f×", lineSpacing)
 }
 
 private fun formatEpubCssPercent(value: Float): String {

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
@@ -2958,6 +2958,19 @@ internal fun ReaderConfigurationControls(
                 }
             }
         }
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                "Line spacing ${formatEpubLineSpacing(value.lineSpacing)}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            Slider(
+                value = value.lineSpacing,
+                onValueChange = { onPreferencesChange(value.copy(lineSpacing = it)) },
+                valueRange = DEFAULT_EPUB_LINE_SPACING..MAX_EPUB_LINE_SPACING,
+                steps = 9,
+                modifier = Modifier.testTag("$testTagPrefix-line-spacing")
+            )
+        }
     }
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/vangeaux/lagrange/LibraryReaderPreferences.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/LibraryReaderPreferences.kt
@@ -36,6 +36,8 @@ internal val EPUB_ACCESSIBILITY_FONT_FAMILY_OPTIONS = listOf(
 
 internal const val DEFAULT_READER_PAGE_GAP_DP = 16f
 internal const val MAX_READER_PAGE_GAP_DP = 48f
+internal const val DEFAULT_EPUB_LINE_SPACING = 1f
+internal const val MAX_EPUB_LINE_SPACING = 2f
 
 private const val READER_PREFERENCES_STORAGE_VERSION = 1
 private const val READER_PREFERENCES_PROFILES_KEY = "profiles"
@@ -46,6 +48,7 @@ data class LibraryReaderPreferences(
     val fontFamily: EpubReaderFontFamily = EpubReaderFontFamily.PUBLISHER_DEFAULT,
     val customFont: CustomFontRecord? = null,
     val fontScale: Float = 1f,
+    val lineSpacing: Float = DEFAULT_EPUB_LINE_SPACING,
     val padding: EpubPaddingPercentages = EpubPaddingPercentages(),
     val epubLayoutMode: ReaderLayoutMode = ReaderLayoutMode.PAGINATED,
     val pdfLayoutMode: ReaderLayoutMode = ReaderLayoutMode.CONTINUOUS,
@@ -55,6 +58,7 @@ data class LibraryReaderPreferences(
 ) {
     fun normalized(): LibraryReaderPreferences = copy(
         fontScale = fontScale.coerceIn(0.9f, 1.5f),
+        lineSpacing = lineSpacing.coerceIn(DEFAULT_EPUB_LINE_SPACING, MAX_EPUB_LINE_SPACING),
         padding = padding.normalizedReaderPadding(),
         pdfPageGapDp = pdfPageGapDp.coerceIn(0f, MAX_READER_PAGE_GAP_DP),
         comicPageGapDp = comicPageGapDp.coerceIn(0f, MAX_READER_PAGE_GAP_DP)
@@ -129,6 +133,7 @@ private fun libraryReaderPreferenceStorageValue(value: LibraryReaderPreferences)
             put("fontFamily", epubReaderFontFamilyStorageValue(normalized.fontFamily))
             normalized.customFont?.let { put("customFont", customFontStorageValue(it)) }
             put("fontScale", normalized.fontScale.toDouble())
+            put("lineSpacing", normalized.lineSpacing.toDouble())
             put("top", normalized.padding.top.toDouble())
             put("bottom", normalized.padding.bottom.toDouble())
             put("left", normalized.padding.left.toDouble())
@@ -157,6 +162,10 @@ internal fun libraryReaderPreferencesFromStorage(value: String?): Map<String, Li
                         fontFamily = epubReaderFontFamilyFromStorage(item.optString("fontFamily")),
                         customFont = customFontFromStorage(item.optString("customFont")),
                         fontScale = item.optDouble("fontScale", 1.0).toFloat(),
+                        lineSpacing = item.optDouble(
+                            "lineSpacing",
+                            DEFAULT_EPUB_LINE_SPACING.toDouble()
+                        ).toFloat(),
                         padding = EpubPaddingPercentages(
                             top = item.optDouble("top", EPUB_DEFAULT_TOP_PADDING_PERCENT.toDouble()).toFloat(),
                             bottom = item.optDouble("bottom", EPUB_DEFAULT_PADDING_PERCENT.toDouble()).toFloat(),

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
@@ -99,14 +99,15 @@ internal suspend fun openReadiumEpub(
     ReadiumEpubOpenResult.Opened(publication)
 }
 
-internal fun readiumReadingProgression(
+internal fun readiumEpubReadingProgression(
     readingDirection: LibraryReadingDirection
-): ReadiumReadingProgression = if (
-    readingDirection == LibraryReadingDirection.RIGHT_TO_LEFT
-) {
-    ReadiumReadingProgression.RTL
-} else {
-    ReadiumReadingProgression.LTR
+): ReadiumReadingProgression {
+    // LibraryReadingDirection controls physical tap navigation only. Keep EPUB
+    // content/layout direction unchanged so Readium does not alter typography.
+    return when (readingDirection) {
+        LibraryReadingDirection.LEFT_TO_RIGHT,
+        LibraryReadingDirection.RIGHT_TO_LEFT -> ReadiumReadingProgression.LTR
+    }
 }
 
 @OptIn(ExperimentalReadiumApi::class)
@@ -137,7 +138,7 @@ internal fun readiumPreferences(
     },
     fontSize = fontScale.coerceIn(0.9f, 1.5f).toDouble(),
     fontFamily = readiumFontFamily(fontFamily),
-    readingProgression = readiumReadingProgression(readingDirection),
+    readingProgression = readiumEpubReadingProgression(readingDirection),
     pageMargins = 0.0,
     columnCount = ColumnCount.ONE,
     scroll = layoutMode == ReaderLayoutMode.CONTINUOUS

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
@@ -121,10 +121,15 @@ internal fun readiumFontFamily(fontFamily: EpubReaderFontFamily): ReadiumFontFam
     EpubReaderFontFamily.CUSTOM -> null
 }
 
+internal fun readiumEpubLineHeight(lineSpacing: Float): Double = lineSpacing
+    .coerceIn(DEFAULT_EPUB_LINE_SPACING, MAX_EPUB_LINE_SPACING)
+    .toDouble()
+
 @OptIn(ExperimentalReadiumApi::class)
 internal fun readiumPreferences(
     theme: EpubReaderTheme,
     fontScale: Float,
+    lineSpacing: Float = DEFAULT_EPUB_LINE_SPACING,
     readingDirection: LibraryReadingDirection = LibraryReadingDirection.LEFT_TO_RIGHT,
     layoutMode: ReaderLayoutMode = ReaderLayoutMode.PAGINATED,
     fontFamily: EpubReaderFontFamily = EpubReaderFontFamily.PUBLISHER_DEFAULT
@@ -137,11 +142,15 @@ internal fun readiumPreferences(
         EpubReaderTheme.Dark -> ReadiumTheme.DARK
     },
     fontSize = fontScale.coerceIn(0.9f, 1.5f).toDouble(),
+    lineHeight = readiumEpubLineHeight(lineSpacing),
     fontFamily = readiumFontFamily(fontFamily),
     readingProgression = readiumEpubReadingProgression(readingDirection),
     pageMargins = 0.0,
     columnCount = ColumnCount.ONE,
-    scroll = layoutMode == ReaderLayoutMode.CONTINUOUS
+    scroll = layoutMode == ReaderLayoutMode.CONTINUOUS,
+    // Readium only applies lineHeight and the other user CSS overrides when
+    // publisher styles are disabled.
+    publisherStyles = false
 )
 
 internal fun cssHexColorInt(value: String): Int {
@@ -504,6 +513,7 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
             initialPreferences = readiumPreferences(
                 selectedTheme,
                 fontScale,
+                readerPreferences.lineSpacing,
                 readingDirection,
                 epubLayoutMode,
                 selectedFontFamily
@@ -688,6 +698,7 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
             readiumPreferences(
                 normalized.theme,
                 normalized.fontScale,
+                normalized.lineSpacing,
                 normalized.readingDirection,
                 normalized.epubLayoutMode,
                 normalized.fontFamily

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumPdfReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumPdfReaderActivity.kt
@@ -45,6 +45,7 @@ import org.readium.r2.navigator.input.InputListener
 import org.readium.r2.navigator.input.TapEvent
 import org.readium.r2.navigator.pdf.PdfNavigatorFragment
 import org.readium.r2.navigator.preferences.Axis
+import org.readium.r2.navigator.preferences.ReadingProgression as ReadiumReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -100,6 +101,16 @@ internal data class ReadiumPdfProgressResult(
     val pageCount: Int,
     val percent: Float?
 )
+
+internal fun readiumReadingProgression(
+    readingDirection: LibraryReadingDirection
+): ReadiumReadingProgression = if (
+    readingDirection == LibraryReadingDirection.RIGHT_TO_LEFT
+) {
+    ReadiumReadingProgression.RTL
+} else {
+    ReadiumReadingProgression.LTR
+}
 
 internal fun pdfiumPreferencesFor(
     preferences: LibraryReaderPreferences

--- a/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
@@ -160,14 +160,14 @@ class LibraryReaderPreferencesTest {
     }
 
     @Test
-    fun `EPUB preferences apply the library reading progression`() {
+    fun `EPUB preferences keep layout progression left to right for both tap directions`() {
         assertEquals(
             ReadingProgression.LTR,
-            readiumReadingProgression(LibraryReadingDirection.LEFT_TO_RIGHT)
+            readiumEpubReadingProgression(LibraryReadingDirection.LEFT_TO_RIGHT)
         )
         assertEquals(
-            ReadingProgression.RTL,
-            readiumReadingProgression(LibraryReadingDirection.RIGHT_TO_LEFT)
+            ReadingProgression.LTR,
+            readiumEpubReadingProgression(LibraryReadingDirection.RIGHT_TO_LEFT)
         )
     }
 

--- a/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/LibraryReaderPreferencesTest.kt
@@ -17,6 +17,7 @@ class LibraryReaderPreferencesTest {
             theme = EpubReaderTheme.Dark,
             fontFamily = EpubReaderFontFamily.OPEN_DYSLEXIC,
             fontScale = 1.3f,
+            lineSpacing = 1.4f,
             padding = EpubPaddingPercentages(10f, 20f, 30f, 40f),
             epubLayoutMode = ReaderLayoutMode.CONTINUOUS,
             pdfLayoutMode = ReaderLayoutMode.PAGINATED,
@@ -59,6 +60,7 @@ class LibraryReaderPreferencesTest {
             theme = EpubReaderTheme.Light,
             fontFamily = EpubReaderFontFamily.SYSTEM_SANS_SERIF,
             fontScale = 1.2f,
+            lineSpacing = 1.3f,
             padding = EpubPaddingPercentages(10f, 20f, 30f, 40f),
             epubLayoutMode = ReaderLayoutMode.CONTINUOUS,
             pdfLayoutMode = ReaderLayoutMode.PAGINATED,
@@ -91,6 +93,7 @@ class LibraryReaderPreferencesTest {
             LibraryReaderPreferences(
                 readingDirection = LibraryReadingDirection.RIGHT_TO_LEFT,
                 fontScale = 2f,
+                lineSpacing = 3f,
                 padding = EpubPaddingPercentages(-1f, 101f, 25f, 50f),
                 pdfPageGapDp = -10f,
                 comicPageGapDp = 100f
@@ -99,6 +102,7 @@ class LibraryReaderPreferencesTest {
 
         assertEquals(LibraryReadingDirection.RIGHT_TO_LEFT, initial.readerPreferencesFor("manga").readingDirection)
         assertEquals(1.5f, initial.readerPreferencesFor("manga").fontScale)
+        assertEquals(MAX_EPUB_LINE_SPACING, initial.readerPreferencesFor("manga").lineSpacing)
         assertEquals(EpubPaddingPercentages(0f, 100f, 25f, 50f), initial.readerPreferencesFor("manga").padding)
         assertEquals(0f, initial.readerPreferencesFor("manga").pdfPageGapDp)
         assertEquals(MAX_READER_PAGE_GAP_DP, initial.readerPreferencesFor("manga").comicPageGapDp)
@@ -117,6 +121,7 @@ class LibraryReaderPreferencesTest {
         assertEquals(DEFAULT_READER_PAGE_GAP_DP, decoded.pdfPageGapDp)
         assertEquals(DEFAULT_READER_PAGE_GAP_DP, decoded.comicPageGapDp)
         assertEquals(EpubReaderFontFamily.PUBLISHER_DEFAULT, decoded.fontFamily)
+        assertEquals(DEFAULT_EPUB_LINE_SPACING, decoded.lineSpacing)
     }
 
     @Test
@@ -168,6 +173,51 @@ class LibraryReaderPreferencesTest {
         assertEquals(
             ReadingProgression.LTR,
             readiumEpubReadingProgression(LibraryReadingDirection.RIGHT_TO_LEFT)
+        )
+    }
+
+    @Test
+    fun `EPUB line spacing maps to Readium line height and clamps`() {
+        assertEquals(
+            1.4,
+            readiumEpubLineHeight(1.4f),
+            0.0001
+        )
+        assertEquals(
+            MAX_EPUB_LINE_SPACING.toDouble(),
+            readiumEpubLineHeight(3f),
+            0.0001
+        )
+    }
+
+    @Test
+    fun `reader options height defaults and clamps within drag bounds`() {
+        assertEquals(
+            READER_OPTIONS_DEFAULT_HEIGHT_FRACTION,
+            readerOptionsHeightFractionAfterDrag(
+                currentFraction = READER_OPTIONS_DEFAULT_HEIGHT_FRACTION,
+                dragAmountPx = 0f,
+                containerHeightPx = 600f
+            ),
+            0f
+        )
+        assertEquals(
+            READER_OPTIONS_MAX_HEIGHT_FRACTION,
+            readerOptionsHeightFractionAfterDrag(
+                currentFraction = READER_OPTIONS_DEFAULT_HEIGHT_FRACTION,
+                dragAmountPx = -600f,
+                containerHeightPx = 600f
+            ),
+            0f
+        )
+        assertEquals(
+            READER_OPTIONS_MIN_HEIGHT_FRACTION,
+            readerOptionsHeightFractionAfterDrag(
+                currentFraction = READER_OPTIONS_DEFAULT_HEIGHT_FRACTION,
+                dragAmountPx = 600f,
+                containerHeightPx = 600f
+            ),
+            0f
         )
     }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ This document contains the current project direction only. Historical work order
 - Release: Lagrange 1.4.1 is published. See [`docs/release-notes/v1.4.1.md`](release-notes/v1.4.1.md).
 - Branch: `main`, aligned with `origin/main`.
 - Recent completed work: behavior-neutral cleanup, release integration, pull-to-refresh, continuous EPUB seeking, reader fonts including one imported custom font, staged startup, server-missing catalog state, and download lifecycle implementation.
-- Current implementation state: no new implementation task has been selected. Choose the next item with the user before editing.
+- Current implementation state: issue #23 reader-options resizing and persisted EPUB line spacing are implemented and user-confirmed on-device; complete device validation for the unrelated download/session follow-ups before release handoff.
 
 ## Active validation and follow-up
 
@@ -18,6 +18,7 @@ This document contains the current project direction only. Historical work order
 5. Treat broader offline RAR/7z extraction and other optional validation as user-directed follow-up, not an implementation blocker for the current release.
 6. [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
 7. [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
+11. [x] [#23](https://github.com/van-geaux/lagrange-reader/issues/23): make the reading-options window adjustable for live preview, with a default height of approximately two-thirds of the screen so the reader remains visible while settings are changed; include the already requested persisted EPUB line-spacing option. Automated coverage and user-confirmed on-device validation are complete.
 
 ## Decision and documentation rules
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,7 @@ This document contains the current project direction only. Historical work order
 4. Consider additional format support only through a new user-approved work item; MOBI, AZW, AZW3, and FB2 remain unsupported.
 5. Treat broader offline RAR/7z extraction and other optional validation as user-directed follow-up, not an implementation blocker for the current release.
 6. [x] [#19](https://github.com/van-geaux/lagrange-reader/issues/19): preserve current-package reader appearance preferences through a versioned, tolerant per-library store; legacy flat profiles remain readable, and old-package migration remains intentionally out of scope.
+7. [x] [#24](https://github.com/van-geaux/lagrange-reader/issues/24): keep EPUB reading-direction changes limited to switching the left-to-right/right-to-left tap region; preserve text alignment, punctuation placement, and all other typography/layout settings. Automated coverage and user-confirmed on-device validation are complete.
 
 ## Decision and documentation rules
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,8 @@ When the affected scope requires it, verify:
 - PDF/comic page navigation and progress;
 - audiobook compact-player restoration, seeking, chapters, and speed;
 - reader settings persistence per library; issue #19 current-package APK-upgrade persistence was user-confirmed working on the supplied debug build;
+- EPUB reader options open at approximately two-thirds of the reader surface, the top handle exposes a minimum 48 dp touch target and expands/contracts the sheet without losing the live reader preview, and the EPUB line-spacing slider updates the preview and persists after reopening the options. User-confirmed on the rebuilt debug APK;
+- changing line spacing or the options-sheet height preserves the other reader settings, including theme, font, direction, margins, and layout;
 - same-application-ID APK upgrade preserves EPUB theme/font/size/margins and the applicable PDF/comic direction, layout, and page-gap settings for more than one library;
 - the reader preference store accepts legacy flat profiles and preserves valid profiles when another stored profile is malformed; migration from the retired `com.bookorbit.android` package is intentionally out of scope;
 - server-missing versus locally deleted state;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -60,6 +60,7 @@ When the affected scope requires it, verify:
 
 - normal and Preview launch isolation;
 - EPUB resume and continuous-mode active-resource seeking;
+- EPUB reading-direction changes preserve text alignment, punctuation, and other typography/layout settings while only reversing left/right edge tap navigation; verify both directions in paginated and continuous modes. User-confirmed on the rebuilt debug APK;
 - PDF/comic page navigation and progress;
 - audiobook compact-player restoration, seeking, chapters, and speed;
 - reader settings persistence per library; issue #19 current-package APK-upgrade persistence was user-confirmed working on the supplied debug build;

--- a/docs/ui-ux.md
+++ b/docs/ui-ux.md
@@ -19,6 +19,7 @@ This document contains current interaction contracts, design rules, and unresolv
 - Pull-to-refresh is user-initiated, non-blocking, duplicate-safe, and independent from background synchronization and destructive download actions.
 - Server-missing catalog records remain visible with a yellow `Missing!` overlay; this is distinct from a locally deleted copy.
 - EPUB-only reader font controls include Publisher default, built-in normal/accessibility choices, and one imported custom font slot.
+- EPUB reader options open at approximately two-thirds of the available reader surface. The top handle is fixed outside the scrollable settings, exposes a minimum 48 dp touch target, and resizes the session-only sheet within bounded limits. EPUB line spacing is a persisted 1.0×–2.0× live-preview option and is applied through Readium’s user CSS preferences.
 - Audiobook session history is local and exact-position; server reading history is analytics context and is not used as a seek position.
 
 ## Current visual rules


### PR DESCRIPTION
## Summary
- Add a custom reader-options sheet with a two-thirds default height and bounded drag resizing.
- Keep the resize handle fixed outside the scrollable settings with a minimum 48 dp touch target.
- Persist EPUB line spacing from 1.0x to 2.0x and apply it live through Readium user CSS preferences.
- Update focused JVM and instrumentation coverage plus reader documentation.

## Verification
- `./gradlew :app:testDebugUnitTest --tests com.vangeaux.lagrange.LibraryReaderPreferencesTest --no-daemon --console=plain`
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin --no-daemon --console=plain`
- `./gradlew :app:lintDebug :app:assembleDebug --no-daemon --console=plain`
- User-confirmed line-spacing behavior on the rebuilt debug APK.
- Instrumentation execution requires a connected Android device/emulator.

Closes #23