### PR TITLE
chore: prepare Lagrange 1.4.2 release

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4,8 +4,8 @@ This is the active completion and validation checklist. Historical completed wor
 
 ## Current release
 
-- [x] Lagrange 1.4.1 released and integrated into `main`.
-- [x] Release notes, signed asset, release workflow, merge state, and current branch state verified.
+- [ ] Lagrange 1.4.2 release candidate prepared; release publication and integration remain pending.
+- [ ] Release notes, signed asset, release workflow, merge state, and current branch state will be verified after publication.
 - [x] Current debug/unit/Android-test compilation and release-related verification recorded in the handover and testing documents.
 
 ## Current implementation status

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 An offline-first Android reader for BookOrbit.
 
 [![License: Personal and Non-Commercial](https://img.shields.io/badge/license-personal--non--commercial-orange)](LICENSE)
-[![Version 1.4.1](https://img.shields.io/badge/version-1.4.1-blue)](https://github.com/van-geaux/lagrange-reader/releases/tag/v1.4.1)
+[![Version 1.4.2](https://img.shields.io/badge/version-1.4.2-blue)](https://github.com/van-geaux/lagrange-reader/releases/tag/v1.4.2)
 [![Build](https://img.shields.io/github/actions/workflow/status/van-geaux/lagrange-reader/android-debug.yml?branch=main&label=build)](https://github.com/van-geaux/lagrange-reader/actions/workflows/android-debug.yml)
 
 </div>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         targetSdk = 35
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Release marker: update versionCode and versionName together for every distributed build.
-        versionCode = 18
-        versionName = "1.4.1"
+        versionCode = 19
+        versionName = "1.4.2"
     }
 
     signingConfigs {

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,6 @@ The session handover and historical operator archives are intentionally kept loc
 
 ## Current status
 
-Lagrange 1.4.1 is the latest published release. The current branch is `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, offline downloads, EPUB/PDF/comic reading, audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, and the implemented interim server sign-in WebView.
+Lagrange 1.4.1 is the latest published release; 1.4.2 is the approved release candidate. The current branch is `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, offline downloads, EPUB/PDF/comic reading, audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, server reading sessions, indexed book navigation, and the implemented interim server sign-in WebView.
 
 Use `CHECKLIST.md` for active completion and validation items and `docs/roadmap.md` for the next user-directed work. Session-specific worktree state belongs in the local-only `docs/handover.md`; do not use historical archives as current status without re-verification.

--- a/docs/release-notes/v1.4.2.md
+++ b/docs/release-notes/v1.4.2.md
@@ -1,0 +1,32 @@
+# Lagrange 1.4.2
+
+## Features
+
+- [#21](https://github.com/van-geaux/lagrange-reader/issues/21) Added server-registered reading sessions and attempts across EPUB/KEPUB, PDF, CBZ/CBR/CB7, and audiobooks.
+  - Sessions are queued for offline delivery, retried with stable identifiers, and kept separate from local exact-position audiobook history.
+  - Preview, paused/background time, and audiobook screen-open without playback remain excluded from session tracking.
+- [#20](https://github.com/van-geaux/lagrange-reader/issues/20) Added indexed Previous/Next book navigation with current-library and format-family preference, library-order fallback, audiobook-family handling, duplicate-index handling, and boundary protection.
+
+## Improvements
+
+- [444c64a](https://github.com/van-geaux/lagrange-reader/commit/444c64a7955e9734c61a9454dd92cecd546a6937) Made the reader-options window adjustable for live preview and added persisted EPUB line spacing.
+  - The options sheet opens at approximately two-thirds of the reader surface and can contract to a handle-only strip without dismissing the live preview.
+- [3b0dba3](https://github.com/van-geaux/lagrange-reader/commit/3b0dba3865551c732e7471749f1b4b9be9d45d3c) Added persisted EPUB word spacing through a live 0.0–1.0 rem Readium user-CSS control.
+- [eaf68a8](https://github.com/van-geaux/lagrange-reader/commit/eaf68a883c55dcf70d96169b0641f85b58c52028) Added configurable reader tap-zone layouts and horizontal/vertical inversion for EPUB, PDF, paginated comics, and continuous comic mode.
+  - The default layout uses equal Previous/Menu/Next thirds; changing the layout or inversion re-shows the tutorial over the reading surface while keeping the options sheet above it.
+- [a663eb1](https://github.com/van-geaux/lagrange-reader/commit/a663eb114441786023112f719ba550c881d37646) Wrapped reader-option groups onto additional rows on narrow screens so the complete set remains usable without horizontal swiping.
+
+## Fixes
+
+- [0d2e7d7](https://github.com/van-geaux/lagrange-reader/commit/0d2e7d7c824fdfb578233ae50251892c898b6bab) Kept EPUB reading-direction changes limited to left/right tap navigation without changing text alignment, punctuation placement, or unrelated typography/layout settings.
+- [de6922c](https://github.com/van-geaux/lagrange-reader/commit/de6922cfc952d28a1fff1bd0a3c7ada35cdf1648) Preserved current-package reader appearance preferences through a versioned, tolerant per-library store.
+
+## Others
+
+- Known limitations and deferred work:
+  - BOOX/Android e-ink physical validation remains deferred pending a response from a user who has access to the device. The current `minSdk = 26` remains unchanged.
+  - Native AppAuth/Custom Tabs OIDC remains deferred until BookOrbit provides deployed mobile-redirect support and the identity-provider callback is registered.
+  - MOBI, AZW, AZW3, and FB2 remain unsupported.
+  - Broader offline RAR/7z extraction and additional product work remain deferred.
+- Upgrade notes:
+  - No migration action is required for the documented reader settings, downloads, progress, or local audiobook history.

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,7 +36,7 @@ If a rename is required again in the future:
 
 ### Current version marker
 
-- current release: `versionName 1.4.1`, `versionCode 18`
+- current release: `versionName 1.4.2`, `versionCode 19`
 - update both values at the marked `versionCode`/`versionName` lines in [`app/build.gradle.kts`](../app/build.gradle.kts) when preparing a distributed build
 - the About screen reads `BuildConfig.VERSION_NAME`; do not hardcode a second version there
 - use the `1.x` minor-release line for additive feature releases and increment `versionCode` for every distributed build

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ This document contains the current project direction only. Historical work order
 
 ## Current status
 
-- Release: Lagrange 1.4.1 is published. See [`docs/release-notes/v1.4.1.md`](release-notes/v1.4.1.md).
+- Release: Lagrange 1.4.1 is published; the approved 1.4.2 release candidate is being prepared. See [`docs/release-notes/v1.4.2.md`](release-notes/v1.4.2.md).
 - Branch: `main`, aligned with `origin/main`.
 - Recent completed work: behavior-neutral cleanup, release integration, pull-to-refresh, continuous EPUB seeking, reader fonts including one imported custom font, staged startup, server-missing catalog state, and download lifecycle implementation.
 - Current implementation state: issue #23 reader-options resizing and persisted EPUB line spacing, the download lifecycle, indexed navigation, and server reading sessions are implemented and user-confirmed working. New implementation work is deferred; BOOX issue #25 remains pending physical-device access.


### PR DESCRIPTION
## Summary
- Bump the Android package to version 1.4.2 / versionCode 19.
- Add the finalized user-edited release notes.
- Update release policy, README badge, roadmap, checklist, and documentation index for the release candidate.

## Verification
- `./gradlew assembleDebug --no-daemon --console=plain`
- UTF-8 and mojibake scan passed.
- CRLF-aware `git diff --check` passed.
- Signed release assembly is delegated to `.github/workflows/android-release.yml` because no local keystore is present.
