### PR TITLE
docs: mark Lagrange 1.4.2 published

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4,8 +4,8 @@ This is the active completion and validation checklist. Historical completed wor
 
 ## Current release
 
-- [ ] Lagrange 1.4.2 release candidate prepared; release publication and integration remain pending.
-- [ ] Release notes, signed asset, release workflow, merge state, and current branch state will be verified after publication.
+- [x] Lagrange 1.4.2 released and integrated into `main`.
+- [x] Release notes, signed asset, release workflow, merge state, and current branch state verified.
 - [x] Current debug/unit/Android-test compilation and release-related verification recorded in the handover and testing documents.
 
 ## Current implementation status

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,6 @@ The session handover and historical operator archives are intentionally kept loc
 
 ## Current status
 
-Lagrange 1.4.1 is the latest published release; 1.4.2 is the approved release candidate. The current branch is `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, offline downloads, EPUB/PDF/comic reading, audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, server reading sessions, indexed book navigation, and the implemented interim server sign-in WebView.
+Lagrange 1.4.2 is the latest published release. The current branch is `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, offline downloads, EPUB/PDF/comic reading, audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, server reading sessions, indexed book navigation, and the implemented interim server sign-in WebView.
 
 Use `CHECKLIST.md` for active completion and validation items and `docs/roadmap.md` for the next user-directed work. Session-specific worktree state belongs in the local-only `docs/handover.md`; do not use historical archives as current status without re-verification.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ This document contains the current project direction only. Historical work order
 
 ## Current status
 
-- Release: Lagrange 1.4.1 is published; the approved 1.4.2 release candidate is being prepared. See [`docs/release-notes/v1.4.2.md`](release-notes/v1.4.2.md).
+- Release: Lagrange 1.4.2 is published. See [`docs/release-notes/v1.4.2.md`](release-notes/v1.4.2.md).
 - Branch: `main`, aligned with `origin/main`.
 - Recent completed work: behavior-neutral cleanup, release integration, pull-to-refresh, continuous EPUB seeking, reader fonts including one imported custom font, staged startup, server-missing catalog state, and download lifecycle implementation.
 - Current implementation state: issue #23 reader-options resizing and persisted EPUB line spacing, the download lifecycle, indexed navigation, and server reading sessions are implemented and user-confirmed working. New implementation work is deferred; BOOX issue #25 remains pending physical-device access.


### PR DESCRIPTION
## Summary
- Mark Lagrange 1.4.2 as published in the documentation index, checklist, and roadmap.
- Record that the signed asset, release workflow, merge state, and branch state were verified.

## Verification
- GitHub Release `v1.4.2` is non-draft/non-prerelease.
- Android Release workflow run `30869174239` succeeded.
- Asset `Lagrange-1.4.2.apk` is published.
