### PR TITLE
docs: mark Lagrange 1.4.3 published

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -4,9 +4,9 @@ This is the active completion and validation checklist. Historical completed wor
 
 ## Current release
 
-- [x] Lagrange 1.4.3 release scope is integrated into `main`; publication is in progress.
-- [x] Release notes, merged feature state, release workflow, and current branch state verified.
-- [ ] Signed 1.4.3 asset, GitHub Release, tag, and post-publication state remain to be verified.
+- [x] Lagrange 1.4.3 released and integrated into `main`.
+- [x] Release notes, signed asset, release workflow, merge state, and current branch state verified.
+- [x] Current debug/unit/Android-test compilation and release-related verification recorded in the release notes and testing documents.
 
 ## Current implementation status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,6 @@ The session handover and historical operator archives are intentionally kept loc
 
 ## Current status
 
-Lagrange 1.4.3 is the release being prepared from `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, selected-library offline caching, series and library bulk downloads, EPUB/PDF/comic reading, continuous connected split-MP3 audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, server reading sessions, indexed book navigation, recreation-safe reader state, and the implemented interim server sign-in WebView.
+Lagrange 1.4.3 is the latest published release. The current branch is `main`, aligned with `origin/main`. The application supports authenticated BookOrbit browsing, selected-library offline caching, series and library bulk downloads, EPUB/PDF/comic reading, continuous connected split-MP3 audiobook playback, progress synchronization, server-missing catalog state, pull-to-refresh, reader font selection, server reading sessions, indexed book navigation, recreation-safe reader state, and the implemented interim server sign-in WebView.
 
 Use `CHECKLIST.md` for active completion and validation items and `docs/roadmap.md` for the next user-directed work. Session-specific worktree state belongs in the local-only `docs/handover.md`; do not use historical archives as current status without re-verification.

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,7 +36,7 @@ If a rename is required again in the future:
 
 ### Current version marker
 
-- current release being prepared: `versionName 1.4.3`, `versionCode 20`
+- current published release: `versionName 1.4.3`, `versionCode 20`
 - update both values at the marked `versionCode`/`versionName` lines in [`app/build.gradle.kts`](../app/build.gradle.kts) when preparing a distributed build
 - the About screen reads `BuildConfig.VERSION_NAME`; do not hardcode a second version there
 - use the `1.x` minor-release line for additive feature releases and increment `versionCode` for every distributed build

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ This document contains the current project direction only. Historical work order
 
 ## Current status
 
-- Release: Lagrange 1.4.3 is being prepared from the integrated `main` scope. See [`docs/release-notes/v1.4.3.md`](release-notes/v1.4.3.md).
+- Release: Lagrange 1.4.3 is published. See [`docs/release-notes/v1.4.3.md`](release-notes/v1.4.3.md).
 - Branch: `main`, aligned with `origin/main`.
 - Recent completed work: behavior-neutral cleanup, release integration, pull-to-refresh, continuous EPUB seeking, reader fonts including one imported custom font, staged startup, server-missing catalog state, and download lifecycle implementation.
 - Current implementation state: issue #23 reader-options resizing and persisted EPUB line spacing, the download lifecycle, indexed navigation, server reading sessions, issue #36 streamed split-MP3 playback, issue #37 Available file selection, issue #38 bulk downloads, issue #42 cached-series navigation, issue #43 selected-library offline caching, issue #47 orientation/fold restoration, and issue #50 About-screen update checking are implemented and user-confirmed working. BOOX issue #25 remains pending physical-device access; issues #40 and #41 remain follow-up delivery work outside this release scope.


### PR DESCRIPTION
Update current-facing release markers after the verified v1.4.3 GitHub Release publication.\n\nVerification: git -c core.whitespace=cr-at-eol diff --check