### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+Lagrange Reader is the Android client for the `van-geaux/lagrange-reader` repository. This policy explains how to report a security concern responsibly.
+
+## Supported versions
+
+Please report issues against the latest publicly available version. Older versions may not receive security fixes; support for a particular version is assessed during triage rather than guaranteed for a fixed time window.
+
+## Reporting a vulnerability
+
+No security contact is currently published for this repository. Please use GitHub's private vulnerability reporting or security-advisory channel for `van-geaux/lagrange-reader` if it is available. If it is not available, contact the maintainer privately through GitHub before making any public disclosure. Do not open a public issue for an unpatched vulnerability.
+
+Include, where safe to share:
+
+- a clear description of the issue and its security impact;
+- affected app version, Android version, and BookOrbit/server context;
+- reproducible steps or a minimal proof of concept;
+- relevant logs, screenshots, traces, or sample requests with sensitive values removed.
+
+Never include passwords, session cookies, access/refresh tokens, private keys, personal data, or live server credentials. Redact secrets before sending and revoke or rotate any credential that may have been exposed.
+
+## Triage and coordination
+
+The maintainer will review reports, may request clarification or a minimal reproduction, and will coordinate scope, remediation, and any public disclosure timeline with the reporter. Please allow reasonable time for investigation and a fix before disclosure. Do not test against systems or accounts without authorization.
+
+## Scope and upstream reporting
+
+The app stores cookies/session data and downloaded content locally, so reports should explain the affected storage or access boundary where relevant. The app recommends HTTPS, does not bypass TLS errors in its interim server-hosted WebView sign-in flow, and keeps authentication-origin, TLS, cookie, token, and redirect checks separate. These safeguards do not make every deployment or network secure.
+
+Issues in a BookOrbit server or an identity provider may require reporting to the relevant upstream maintainer or provider as well as, or instead of, this repository. Please avoid including another party's confidential information in a report here.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This folder contains focused public engineering documentation for Lagrange Reade
 - [UI/UX Workstream](./ui-ux.md) — current interaction contracts, design rules, and unresolved UX decisions.
 - [Roadmap](./roadmap.md) — current priorities and deferred work.
 - [OIDC / SSO Authentication](./oidc-authentication.md) — current interim flow and native AppAuth blocker.
+- [Security Policy](../SECURITY.md) — responsible-disclosure guidance for security reports.
 
 ## Local operator documents
 


### PR DESCRIPTION
## Summary
- Add responsible-disclosure guidance in SECURITY.md
- Index the security policy in the public documentation list

## Verification
- UTF-8 and mojibake checks passed
- Markdown link resolves
- CRLF-aware git diff --check passed
- No application build required (documentation-only change)