### PR TITLE
feat: add synced EPUB annotation foundation

### DIFF
--- a/app/src/main/assets/foliate-selection-cfi.js
+++ b/app/src/main/assets/foliate-selection-cfi.js
@@ -1,0 +1,110 @@
+/*
+ * Selection-range EPUB CFI generation adapted from foliate-js/epubcfi.js.
+ * Source: https://github.com/johnfactotum/foliate-js/blob/main/epubcfi.js
+ *
+ * MIT License
+ * Copyright (c) 2022 John Factotum
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+(function () {
+    const escapeCFI = value => value.replace(/[\^[\](),;=]/g, '^$&');
+    const wrap = value => `epubcfi(${value})`;
+
+    const getChildNodes = node => Array.from(node.childNodes)
+        .filter(child => child.nodeType === Node.TEXT_NODE ||
+            child.nodeType === Node.CDATA_SECTION_NODE ||
+            child.nodeType === Node.ELEMENT_NODE);
+
+    const indexChildNodes = node => {
+        const nodes = getChildNodes(node).reduce((result, child) => {
+            const last = result[result.length - 1];
+            const isText = child.nodeType === Node.TEXT_NODE ||
+                child.nodeType === Node.CDATA_SECTION_NODE;
+            const lastIsText = last && !Array.isArray(last) &&
+                (last.nodeType === Node.TEXT_NODE || last.nodeType === Node.CDATA_SECTION_NODE);
+            if (!last) result.push(child);
+            else if (isText) {
+                if (Array.isArray(last)) last.push(child);
+                else if (lastIsText) result[result.length - 1] = [last, child];
+                else result.push(child);
+            } else {
+                if (last.nodeType === Node.ELEMENT_NODE) result.push(null, child);
+                else result.push(child);
+            }
+            return result;
+        }, []);
+        if (nodes[0]?.nodeType === Node.ELEMENT_NODE) nodes.unshift('first');
+        if (nodes[nodes.length - 1]?.nodeType === Node.ELEMENT_NODE) nodes.push('last');
+        nodes.unshift('before');
+        nodes.push('after');
+        return nodes;
+    };
+
+    const nodeToParts = (node, offset) => {
+        const parentNode = node.parentNode;
+        const indexed = indexChildNodes(parentNode);
+        const index = indexed.findIndex(item =>
+            Array.isArray(item) ? item.some(part => part === node) : item === node);
+        const chunk = indexed[index];
+        if (Array.isArray(chunk)) {
+            let sum = 0;
+            for (const part of chunk) {
+                if (part === node) {
+                    sum += offset;
+                    break;
+                }
+                sum += part.nodeValue.length;
+            }
+            offset = sum;
+        }
+        const part = { id: node.id, index, offset };
+        const root = node.ownerDocument.documentElement;
+        return (parentNode !== root ? nodeToParts(parentNode, null).concat(part) : [part])
+            .filter(value => value.index !== -1);
+    };
+
+    const partToString = ({ index, id, offset }) => `/${index}` +
+        (id ? `[${escapeCFI(id)}]` : '') +
+        (offset != null && index % 2 ? `:${offset}` : '');
+
+    const commonParentLength = (start, end) => {
+        const length = Math.min(start.length, end.length);
+        let index = 0;
+        while (index < length && start[index].index === end[index].index &&
+            start[index].offset == null && end[index].offset == null) index += 1;
+        return index;
+    };
+
+    const fromRange = range => {
+        const start = nodeToParts(range.startContainer, range.startOffset);
+        const end = nodeToParts(range.endContainer, range.endOffset);
+        if (range.collapsed) return null;
+        const parentLength = commonParentLength(start, end);
+        const parent = start.slice(0, parentLength).map(partToString).join('');
+        const startPath = start.slice(parentLength).map(partToString).join('');
+        const endPath = end.slice(parentLength).map(partToString).join('');
+        if (!parent || !startPath || !endPath) return null;
+        return wrap(`${parent},${startPath},${endPath}`);
+    };
+
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || selection.rangeCount < 1) return null;
+    return fromRange(selection.getRangeAt(0));
+})();

--- a/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationQueueStore.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationQueueStore.kt
@@ -1,0 +1,226 @@
+package com.vangeaux.lagrange
+
+import android.content.Context
+import java.io.File
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal const val LOCAL_ANNOTATION_ID_PREFIX = "local:"
+
+internal enum class AnnotationMutationOp {
+    CREATE,
+    UPDATE,
+    DELETE
+}
+
+internal data class AnnotationMutationPayload(
+    val annotationId: String,
+    val serverUrl: String = "",
+    val bookId: String = "",
+    val op: AnnotationMutationOp,
+    val cfi: String? = null,
+    val bookFileId: String? = null,
+    val text: String? = null,
+    val color: String? = null,
+    val style: String? = null,
+    val note: String? = null,
+    val noteSpecified: Boolean = false,
+    val chapterTitle: String? = null,
+    val updatedAtMillis: Long = System.currentTimeMillis()
+)
+
+/**
+ * A pending create is collapsed with any later edit/delete for the same [AnnotationMutationPayload.annotationId]
+ * instead of appending a second entry, since the create has not reached the server yet and there is no
+ * server-assigned id to reference. This keeps every queued item addressable by a single stable id and avoids
+ * ever inventing a fake server id.
+ */
+internal class AnnotationMutationQueueStore private constructor(
+    private val file: File,
+    @Suppress("UNUSED_PARAMETER") private val directFileConstructor: Boolean
+) {
+    constructor(context: Context) : this(
+        file = File(context.filesDir, "pending_annotation_mutations.json"),
+        directFileConstructor = true
+    )
+
+    internal constructor(filesDir: File) : this(
+        file = File(filesDir, "pending_annotation_mutations.json"),
+        directFileConstructor = true
+    )
+
+    suspend fun readAll(): List<AnnotationMutationPayload> = mutex.withLock {
+        readUnlocked()
+    }
+
+    suspend fun enqueue(payload: AnnotationMutationPayload) = mutex.withLock {
+        writeUnlocked(collapse(readUnlocked(), payload))
+    }
+
+    suspend fun acknowledge(annotationIds: Set<String>) = mutex.withLock {
+        if (annotationIds.isEmpty()) return@withLock
+        writeUnlocked(readUnlocked().filterNot { it.annotationId in annotationIds })
+    }
+
+    suspend fun countFor(serverUrl: String): Int = mutex.withLock {
+        readUnlocked().count { it.serverUrl == serverUrl }
+    }
+
+    suspend fun clearServer(serverUrl: String) = mutex.withLock {
+        writeUnlocked(readUnlocked().filterNot { it.serverUrl == serverUrl })
+    }
+
+    suspend fun clear() = mutex.withLock {
+        if (file.exists()) file.delete()
+    }
+
+    private fun collapse(
+        current: List<AnnotationMutationPayload>,
+        incoming: AnnotationMutationPayload
+    ): List<AnnotationMutationPayload> {
+        val existing = current.find { it.annotationId == incoming.annotationId }
+        val withoutExisting = current.filterNot { it.annotationId == incoming.annotationId }
+        if (existing == null) return withoutExisting + incoming
+        val merged = when {
+            existing.op == AnnotationMutationOp.CREATE && incoming.op == AnnotationMutationOp.DELETE ->
+                null
+            existing.op == AnnotationMutationOp.CREATE && incoming.op == AnnotationMutationOp.UPDATE ->
+                existing.copy(
+                    text = incoming.text ?: existing.text,
+                    color = incoming.color ?: existing.color,
+                    style = incoming.style ?: existing.style,
+                    note = if (incoming.noteSpecified) incoming.note else existing.note,
+                    noteSpecified = existing.noteSpecified || incoming.noteSpecified,
+                    chapterTitle = incoming.chapterTitle ?: existing.chapterTitle,
+                    updatedAtMillis = incoming.updatedAtMillis
+                )
+            else -> incoming
+        }
+        return if (merged == null) withoutExisting else withoutExisting + merged
+    }
+
+    private fun readUnlocked(): List<AnnotationMutationPayload> {
+        if (!file.exists()) return emptyList()
+        return runCatching {
+            val array = JSONArray(file.readText())
+            buildList {
+                for (index in 0 until array.length()) {
+                    array.optJSONObject(index)?.toPayload()?.let(::add)
+                }
+            }.sortedBy { it.updatedAtMillis }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun writeUnlocked(items: List<AnnotationMutationPayload>) {
+        val array = JSONArray()
+        items.sortedBy { it.updatedAtMillis }.forEach { payload ->
+            array.put(
+                JSONObject().apply {
+                    put("annotationId", payload.annotationId)
+                    put("serverUrl", payload.serverUrl)
+                    put("bookId", payload.bookId)
+                    put("op", payload.op.name)
+                    put("cfi", payload.cfi ?: JSONObject.NULL)
+                    put("bookFileId", payload.bookFileId ?: JSONObject.NULL)
+                    put("text", payload.text ?: JSONObject.NULL)
+                    put("color", payload.color ?: JSONObject.NULL)
+                    put("style", payload.style ?: JSONObject.NULL)
+                    put("note", payload.note ?: JSONObject.NULL)
+                    put("noteSpecified", payload.noteSpecified)
+                    put("chapterTitle", payload.chapterTitle ?: JSONObject.NULL)
+                    put("updatedAtMillis", payload.updatedAtMillis)
+                }
+            )
+        }
+        file.parentFile?.mkdirs()
+        file.writeText(array.toString())
+    }
+
+    private fun JSONObject.toPayload(): AnnotationMutationPayload? {
+        val annotationId = optString("annotationId").takeIf { it.isNotBlank() } ?: return null
+        val serverUrl = optString("serverUrl")
+        val bookId = optString("bookId")
+        val op = runCatching { AnnotationMutationOp.valueOf(optString("op")) }.getOrNull() ?: return null
+        return AnnotationMutationPayload(
+            annotationId = annotationId,
+            serverUrl = serverUrl,
+            bookId = bookId,
+            op = op,
+            cfi = optNullableString("cfi"),
+            bookFileId = optNullableString("bookFileId"),
+            text = optNullableString("text"),
+            color = optNullableString("color"),
+            style = optNullableString("style"),
+            note = optNullableString("note"),
+            noteSpecified = optBoolean("noteSpecified", false),
+            chapterTitle = optNullableString("chapterTitle"),
+            updatedAtMillis = optLong("updatedAtMillis")
+        )
+    }
+
+    private fun JSONObject.optNullableString(key: String): String? =
+        if (has(key) && !isNull(key)) optString(key) else null
+
+    private companion object {
+        val mutex = Mutex()
+    }
+}
+
+/**
+ * Once a queued CREATE reaches the server, the durable local annotation is still addressed by its
+ * [LOCAL_ANNOTATION_ID_PREFIX]-prefixed id everywhere else in the app (the UI, any freshly-queued
+ * UPDATE/DELETE). This store remembers the local-id -> server-id association so later mutations can be
+ * resolved to the real id before they are ever sent, instead of a local id silently being posted to the
+ * server as though it were a server-assigned one.
+ */
+internal class AnnotationLocalIdMappingStore private constructor(
+    private val file: File,
+    @Suppress("UNUSED_PARAMETER") private val directFileConstructor: Boolean
+) {
+    constructor(context: Context) : this(
+        file = File(context.filesDir, "annotation_local_id_mappings.json"),
+        directFileConstructor = true
+    )
+
+    internal constructor(filesDir: File) : this(
+        file = File(filesDir, "annotation_local_id_mappings.json"),
+        directFileConstructor = true
+    )
+
+    suspend fun resolve(id: String): String = mutex.withLock {
+        if (!id.startsWith(LOCAL_ANNOTATION_ID_PREFIX)) return@withLock id
+        readUnlocked()[id] ?: id
+    }
+
+    suspend fun readAll(): Map<String, String> = mutex.withLock { readUnlocked() }
+
+    suspend fun remember(localId: String, serverId: String) = mutex.withLock {
+        if (!localId.startsWith(LOCAL_ANNOTATION_ID_PREFIX) || serverId.isBlank()) return@withLock
+        val current = readUnlocked().toMutableMap()
+        current[localId] = serverId
+        writeUnlocked(current)
+    }
+
+    private fun readUnlocked(): Map<String, String> {
+        if (!file.exists()) return emptyMap()
+        return runCatching {
+            val obj = JSONObject(file.readText())
+            buildMap {
+                obj.keys().forEach { key -> put(key, obj.optString(key)) }
+            }
+        }.getOrDefault(emptyMap())
+    }
+
+    private fun writeUnlocked(map: Map<String, String>) {
+        val obj = JSONObject()
+        map.forEach { (key, value) -> obj.put(key, value) }
+        file.parentFile?.mkdirs()
+        file.writeText(obj.toString())
+    }
+
+    private companion object {
+        val mutex = Mutex()
+    }
+}

--- a/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationSyncWorker.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationSyncWorker.kt
@@ -1,0 +1,20 @@
+package com.vangeaux.lagrange
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+internal class AnnotationMutationSyncWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        return runCatching {
+            when (BookOrbitRepository(applicationContext).syncPendingAnnotationMutations()) {
+                SyncAttemptResult.Success,
+                SyncAttemptResult.AuthenticationBlocked -> Result.success()
+                SyncAttemptResult.TransientFailure -> Result.retry()
+            }
+        }.getOrElse { Result.retry() }
+    }
+}

--- a/app/src/main/java/com/vangeaux/lagrange/AnnotationsScreen.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AnnotationsScreen.kt
@@ -1,0 +1,123 @@
+package com.vangeaux.lagrange
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun AnnotationsScreen(
+    loader: suspend (AnnotationsFilter, Int) -> BookAnnotationsPage,
+    onAnnotationSelected: (BookAnnotation) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var query by remember { mutableStateOf("") }
+    var status by remember { mutableStateOf("active") }
+    var hasNote by remember { mutableStateOf<Boolean?>(null) }
+    var sortDir by remember { mutableStateOf("desc") }
+    var page by remember { mutableIntStateOf(1) }
+    var result by remember { mutableStateOf<BookAnnotationsPage?>(null) }
+    var loading by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf(false) }
+
+    LaunchedEffect(query, page, status, hasNote, sortDir) {
+        loading = true
+        error = false
+        runCatching {
+            loader(
+                AnnotationsFilter(search = query, status = status, hasNote = hasNote, sortDir = sortDir),
+                page
+            )
+        }
+            .onSuccess { result = it }
+            .onFailure { error = true }
+        loading = false
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it; page = 1 },
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            singleLine = true,
+            placeholder = { Text("Search highlights and notes") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }
+        )
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            TextButton(onClick = { status = if (status == "active") "trashed" else "active"; page = 1 }) {
+                Text(if (status == "active") "Active" else "Trashed")
+            }
+            TextButton(onClick = { hasNote = if (hasNote == true) null else true; page = 1 }) {
+                Text(if (hasNote == true) "With notes" else "All notes")
+            }
+            TextButton(onClick = { sortDir = if (sortDir == "desc") "asc" else "desc"; page = 1 }) {
+                Text(if (sortDir == "desc") "Newest" else "Oldest")
+            }
+        }
+        when {
+            loading && result == null -> Column(Modifier.padding(16.dp)) { CircularProgressIndicator() }
+            error && result == null -> Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Annotations could not be loaded.")
+                Button(onClick = { page = 1 }) { Text("Retry") }
+            }
+            result?.items.isNullOrEmpty() -> Text("No annotations found.", modifier = Modifier.padding(16.dp))
+            else -> {
+                val current = result ?: return@Column
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(current.items, key = { it.id }) { annotation ->
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 6.dp)
+                                .clickable { onAnnotationSelected(annotation) }
+                        ) {
+                            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text(annotation.bookTitle ?: "Unknown book", style = MaterialTheme.typography.titleMedium)
+                                annotation.author?.takeIf { it.isNotBlank() }?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+                                Text("“${annotation.text}”", style = MaterialTheme.typography.bodyLarge)
+                                annotation.note?.takeIf { it.isNotBlank() }?.let { Text("Note: $it") }
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    annotation.chapterTitle?.takeIf { it.isNotBlank() }?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+                                    annotation.pageno?.let { Text("Page ${it + 1}", style = MaterialTheme.typography.bodySmall) }
+                                }
+                            }
+                        }
+                    }
+                    item {
+                        Row(Modifier.fillMaxWidth().padding(16.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Button(onClick = { page-- }, enabled = page > 1) { Text("Previous") }
+                            Button(onClick = { page++ }, enabled = page * (current.pageSize ?: ANNOTATIONS_PAGE_SIZE) < (current.total ?: 0)) { Text("Next") }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
@@ -117,6 +117,11 @@ class AppCoordinator(
             repository.loadAuthorBooks(authorId, page)
         }
 
+    suspend fun loadAnnotations(filter: AnnotationsFilter, page: Int): BookAnnotationsPage =
+        loadWithSessionRecovery(BookAnnotationsPage()) {
+            repository.loadAnnotations(filter, page)
+        }
+
     suspend fun loadAchievements(): AchievementCatalogue = loadWithSessionRecovery(
         AchievementCatalogue(status = AchievementCatalogueStatus.ERROR)
     ) {
@@ -885,7 +890,27 @@ class AppCoordinator(
         openBook(book, ReaderLaunchMode.PREVIEW)
     }
 
-    private fun openBook(book: BookSummary, launchMode: ReaderLaunchMode) {
+    fun openAnnotation(annotation: BookAnnotation) {
+        openBook(
+            book = annotation.toBookSummary(),
+            launchMode = ReaderLaunchMode.PREVIEW,
+            position = ReaderOpenPosition(
+                cfi = annotation.cfi,
+                pageIndex = annotation.pageno,
+                text = annotation.text,
+                chapterIndex = annotation.chapterIndex,
+                annotationId = annotation.id,
+                color = annotation.color,
+                style = annotation.style
+            )
+        )
+    }
+
+    private fun openBook(
+        book: BookSummary,
+        launchMode: ReaderLaunchMode,
+        position: ReaderOpenPosition? = null
+    ) {
         scope.launch {
             if (book.mediaKind != MediaKind.AUDIO) {
                 _screen.value = AppScreen.ReaderLoading(book, launchMode)
@@ -937,7 +962,13 @@ class AppCoordinator(
                 val readerState = if (launchMode == ReaderLaunchMode.PREVIEW) {
                     preparedState.copy(
                         lastKnownPosition = 0L,
-                        pageIndex = 0,
+                        pageIndex = position?.pageIndex ?: 0,
+                        initialCfi = position?.cfi,
+                        annotationText = position?.text,
+                        annotationChapterIndex = position?.chapterIndex,
+                        annotationId = position?.annotationId,
+                        annotationColor = position?.color,
+                        annotationStyle = position?.style,
                         progressPercent = null,
                         audioFiles = audioFiles,
                         launchMode = ReaderLaunchMode.PREVIEW

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
@@ -289,6 +289,8 @@ private fun BookOrbitDestination(
             seriesCatalogLoader = coordinator::loadSeriesCatalog,
             authorsCatalogLoader = coordinator::loadAuthorsCatalog,
             authorBooksLoader = coordinator::loadAuthorBooks,
+            annotationsLoader = coordinator::loadAnnotations,
+            onAnnotationSelected = coordinator::openAnnotation,
             achievementsLoader = coordinator::loadAchievements,
             statisticsLoader = coordinator::loadUserStatistics,
             catalogImageLoader = coordinator::loadCatalogImage,
@@ -938,6 +940,12 @@ private fun ReaderScreen(
                 initialPage = if (isPreview) 0 else state.readerPageIndex,
                 initialPageCount = if (isPreview) 1 else state.book.readerPageCount ?: 1,
                 initialPercent = if (isPreview) null else state.progressPercent,
+                initialCfi = state.initialCfi,
+                initialAnnotationText = state.annotationText,
+                initialAnnotationChapterIndex = state.annotationChapterIndex,
+                initialAnnotationId = state.annotationId,
+                initialAnnotationColor = state.annotationColor,
+                initialAnnotationStyle = state.annotationStyle,
                 onProgress = { chapterIndex, pageIndex, pageCount, percent ->
                     readerProgress(
                         state.book.copy(

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.material.icons.filled.DownloadForOffline
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Highlight
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
@@ -155,7 +156,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-internal enum class BrowserDestination { HOME, LIBRARY, SERIES, AUTHORS, LOCAL_BOOKS, STATISTICS, ACHIEVEMENTS, OPTIONS, ABOUT }
+internal enum class BrowserDestination { HOME, LIBRARY, SERIES, AUTHORS, ANNOTATIONS, LOCAL_BOOKS, STATISTICS, ACHIEVEMENTS, OPTIONS, ABOUT }
 private enum class LibraryTab { RECOMMENDED, BROWSE }
 
 private fun <T> browserRouteProperty(
@@ -794,6 +795,8 @@ internal fun NativeLibraryBrowserScreen(
     seriesCatalogLoader: suspend (SeriesCatalogFilter, Int) -> SeriesCatalogPage,
     authorsCatalogLoader: suspend (String?, Int) -> AuthorCatalogPage,
     authorBooksLoader: suspend (String, Int) -> AuthorBooksPage?,
+    annotationsLoader: suspend (AnnotationsFilter, Int) -> BookAnnotationsPage,
+    onAnnotationSelected: (BookAnnotation) -> Unit = {},
     achievementsLoader: suspend () -> AchievementCatalogue,
     statisticsLoader: suspend () -> UserStatistics,
     catalogImageLoader: suspend (String) -> ByteArray?,
@@ -1048,6 +1051,14 @@ internal fun NativeLibraryBrowserScreen(
                     showMoreMenu = false
                     selectedBook = null
                     destination = BrowserDestination.AUTHORS
+                    query = ""
+                    selectedAuthor = null
+                    selectedSeriesKey = null
+                },
+                onAnnotations = {
+                    showMoreMenu = false
+                    selectedBook = null
+                    destination = BrowserDestination.ANNOTATIONS
                     query = ""
                     selectedAuthor = null
                     selectedSeriesKey = null
@@ -1349,6 +1360,7 @@ internal fun NativeLibraryBrowserScreen(
                         destination == BrowserDestination.LIBRARY -> "Libraries"
                         destination == BrowserDestination.SERIES -> "Series"
                         destination == BrowserDestination.AUTHORS -> "Authors"
+                        destination == BrowserDestination.ANNOTATIONS -> "Annotations"
                         destination == BrowserDestination.LOCAL_BOOKS -> "Local books"
                         destination == BrowserDestination.ACHIEVEMENTS -> "Achievements"
                         destination == BrowserDestination.OPTIONS -> "Options"
@@ -1565,6 +1577,11 @@ internal fun NativeLibraryBrowserScreen(
                     loader = authorsCatalogLoader,
                     imageLoader = catalogImageLoader,
                     onAuthorSelected = { author -> selectedAuthor = author }
+                )
+                destination == BrowserDestination.ANNOTATIONS -> AnnotationsScreen(
+                    loader = annotationsLoader,
+                    onAnnotationSelected = onAnnotationSelected,
+                    modifier = Modifier.padding(padding)
                 )
                 destination == BrowserDestination.LOCAL_BOOKS -> LocalBooksScreen(
                     state = state,
@@ -1839,6 +1856,7 @@ private fun BrowserBottomNavigation(
             selected = destination == BrowserDestination.SERIES ||
                 destination == BrowserDestination.AUTHORS ||
                 destination == BrowserDestination.LOCAL_BOOKS ||
+                destination == BrowserDestination.ANNOTATIONS ||
                 destination == BrowserDestination.STATISTICS ||
                 destination == BrowserDestination.ACHIEVEMENTS ||
                 destination == BrowserDestination.OPTIONS ||
@@ -1854,6 +1872,7 @@ private fun BrowserBottomNavigation(
 private fun MoreMenu(
     onSeries: () -> Unit,
     onAuthors: () -> Unit,
+    onAnnotations: () -> Unit,
     onLocalBooks: () -> Unit
 ) {
     Column(
@@ -1876,6 +1895,11 @@ private fun MoreMenu(
             headlineContent = { Text("Authors") },
             leadingContent = { Icon(Icons.Default.Groups, contentDescription = "Authors icon") },
             modifier = Modifier.clickable(onClick = onAuthors)
+        )
+        ListItem(
+            headlineContent = { Text("Annotations") },
+            leadingContent = { Icon(Icons.Default.Highlight, contentDescription = "Annotations icon") },
+            modifier = Modifier.clickable(onClick = onAnnotations)
         )
         ListItem(
             headlineContent = { Text("Local books") },

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
@@ -70,6 +70,7 @@ private const val LIBRARY_PARALLEL_PAGE_THRESHOLD = 4
 private const val COMPLETED_PROGRESS_PERCENT = 99.5f
 private val progressSyncMutex = Mutex()
 private val readingSessionSyncMutex = Mutex()
+private val annotationSyncMutex = Mutex()
 
 internal const val LAGRANGE_GITHUB_RELEASES_API_URL =
     "https://api.github.com/repos/van-geaux/lagrange-reader/releases/latest"
@@ -173,6 +174,12 @@ private enum class ReadingSessionPostResult {
     DEFERRED
 }
 
+private enum class AnnotationMutationPostResult {
+    ACCEPTED,
+    INVALID,
+    DEFERRED
+}
+
 internal fun bookReadingSessionsPath(bookId: String, page: Int, pageSize: Int): String {
     val encodedBookId = java.net.URLEncoder.encode(bookId, Charsets.UTF_8.name())
     return "/api/v1/books/$encodedBookId/sessions" +
@@ -188,6 +195,84 @@ internal fun bookReadingAttemptsPath(bookId: String, page: Int, pageSize: Int): 
 internal fun readingSessionPath(fileId: String): String {
     val encodedFileId = java.net.URLEncoder.encode(fileId, Charsets.UTF_8.name())
     return "/api/v1/books/files/$encodedFileId/sessions"
+}
+
+internal const val ANNOTATIONS_PAGE_SIZE = 30
+
+internal fun annotationsPath(filter: AnnotationsFilter, page: Int, pageSize: Int): String {
+    fun encode(value: String) = java.net.URLEncoder.encode(value, Charsets.UTF_8.name())
+    return buildString {
+        append("/api/v1/annotations?page=${page.coerceAtLeast(1)}&pageSize=${pageSize.coerceAtLeast(1)}")
+        filter.search?.trim()?.takeIf { it.isNotBlank() }?.let { append("&search=").append(encode(it)) }
+        filter.bookId?.trim()?.takeIf { it.isNotBlank() }?.let { append("&bookId=").append(encode(it)) }
+        filter.chapter?.trim()?.takeIf { it.isNotBlank() }?.let { append("&chapter=").append(encode(it)) }
+        filter.colors.takeIf { it.isNotEmpty() }?.let { append("&colors=").append(encode(it.joinToString(","))) }
+        filter.styles.takeIf { it.isNotEmpty() }?.let { append("&styles=").append(encode(it.joinToString(","))) }
+        filter.origins.takeIf { it.isNotEmpty() }?.let { append("&origins=").append(encode(it.joinToString(","))) }
+        filter.dateFrom?.trim()?.takeIf { it.isNotBlank() }?.let { append("&dateFrom=").append(encode(it)) }
+        filter.dateTo?.trim()?.takeIf { it.isNotBlank() }?.let { append("&dateTo=").append(encode(it)) }
+        filter.hasNote?.let { append("&hasNote=").append(it) }
+        append("&status=").append(encode(filter.status))
+        append("&sortBy=").append(encode(filter.sortBy))
+        append("&sortDir=").append(encode(filter.sortDir))
+    }
+}
+
+internal fun annotationsPath(bookId: String): String =
+    "/api/v1/books/${java.net.URLEncoder.encode(bookId, Charsets.UTF_8.name()).replace("+", "%20")}/annotations"
+
+internal fun annotationPath(bookId: String, annotationId: String): String =
+    "${annotationsPath(bookId)}/${java.net.URLEncoder.encode(annotationId, Charsets.UTF_8.name()).replace("+", "%20")}"
+
+internal fun buildCreateAnnotationPayload(item: AnnotationMutationPayload): JSONObject = JSONObject().apply {
+    item.cfi?.let { put("cfi", it) }
+    item.bookFileId?.toIntOrNull()?.let { put("bookFileId", it) }
+    put("text", item.text.orEmpty())
+    put("color", item.color.orEmpty())
+    put("style", item.style.orEmpty())
+    put("note", item.note ?: JSONObject.NULL)
+    put("chapterTitle", item.chapterTitle ?: JSONObject.NULL)
+}
+
+internal fun buildUpdateAnnotationPayload(item: AnnotationMutationPayload): JSONObject = JSONObject().apply {
+    if (item.noteSpecified) put("note", item.note ?: JSONObject.NULL)
+    item.color?.let { put("color", it) }
+    item.style?.let { put("style", it) }
+}
+
+internal fun overlayPendingAnnotations(
+    page: BookAnnotationsPage,
+    pending: List<AnnotationMutationPayload>,
+    mappings: Map<String, String>
+): BookAnnotationsPage {
+    val items = page.items.associateBy { it.id }.toMutableMap()
+    pending.sortedBy { it.updatedAtMillis }.forEach { mutation ->
+        val id = mappings[mutation.annotationId] ?: mutation.annotationId
+        when (mutation.op) {
+            AnnotationMutationOp.CREATE -> if (items[id] == null) {
+                items[id] = BookAnnotation(
+                    id = mutation.annotationId,
+                    bookId = mutation.bookId,
+                    cfi = mutation.cfi,
+                    jumpFileId = mutation.bookFileId,
+                    text = mutation.text,
+                    color = mutation.color,
+                    style = mutation.style,
+                    note = mutation.note,
+                    chapterTitle = mutation.chapterTitle
+                )
+            }
+            AnnotationMutationOp.UPDATE -> items[id]?.let { current ->
+                items[id] = current.copy(
+                    note = if (mutation.noteSpecified) mutation.note else current.note,
+                    color = mutation.color ?: current.color,
+                    style = mutation.style ?: current.style
+                )
+            }
+            AnnotationMutationOp.DELETE -> items.remove(id)
+        }
+    }
+    return page.copy(items = items.values.toList())
 }
 
 internal fun buildReadingSessionPayload(item: ReadingSessionPayload): JSONObject = JSONObject()
@@ -254,6 +339,11 @@ interface BookOrbitDataSource {
         loadSeriesCatalog(filter.query, page)
     suspend fun loadAuthorsCatalog(query: String? = null, page: Int = 0): AuthorCatalogPage = AuthorCatalogPage()
     suspend fun loadAuthorBooks(authorId: String, page: Int = 0): AuthorBooksPage? = null
+    suspend fun loadAnnotations(
+        filter: AnnotationsFilter,
+        page: Int = 1,
+        pageSize: Int = ANNOTATIONS_PAGE_SIZE
+    ): BookAnnotationsPage = BookAnnotationsPage()
     suspend fun loadAchievements(): AchievementCatalogue = AchievementCatalogue(
         status = AchievementCatalogueStatus.UNSUPPORTED
     )
@@ -310,6 +400,20 @@ interface BookOrbitDataSource {
     suspend fun queueReadingSession(payload: ReadingSessionPayload) = Unit
     suspend fun pendingReadingSessionCount(): Int = 0
     suspend fun syncPendingReadingSessions(): SyncAttemptResult = SyncAttemptResult.Success
+    suspend fun createAnnotation(
+        bookId: String,
+        cfi: String?,
+        bookFileId: String?,
+        text: String,
+        color: String,
+        style: String,
+        note: String? = null,
+        chapterTitle: String? = null
+    ): BookAnnotation = BookAnnotation("", bookId, cfi, bookFileId, text = text, color = color, style = style, note = note, chapterTitle = chapterTitle)
+    suspend fun updateAnnotation(bookId: String, annotationId: String, note: String? = null, color: String? = null, style: String? = null) = Unit
+    suspend fun deleteAnnotation(bookId: String, annotationId: String) = Unit
+    suspend fun pendingAnnotationMutationCount(): Int = 0
+    suspend fun syncPendingAnnotationMutations(): SyncAttemptResult = SyncAttemptResult.Success
     suspend fun canReachServer(serverUrl: String): Boolean
     suspend fun checkServer(serverUrl: String): ServerCheckResult
 }
@@ -317,6 +421,8 @@ interface BookOrbitDataSource {
 class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
     private val queueStore = ProgressQueueStore(context)
     private val readingSessionQueueStore = ReadingSessionQueueStore(context)
+    private val annotationMutationQueueStore = AnnotationMutationQueueStore(context)
+    private val annotationLocalIdMappingStore = AnnotationLocalIdMappingStore(context)
     private val downloadStore = DownloadStore(context)
     private val browserSnapshotStore = BrowserSnapshotStore(context)
     private val libraryCatalogStore = LibraryCatalogStore(context)
@@ -787,6 +893,144 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
                 ).withCoverAspectRatios(libraryCoverAspectRatios)
             }
             throw error
+        }
+    }
+
+    override suspend fun loadAnnotations(
+        filter: AnnotationsFilter,
+        page: Int,
+        pageSize: Int
+    ): BookAnnotationsPage = withContext(Dispatchers.IO) {
+        val responsePage = BookOrbitPayloadParser.parseAnnotations(
+            request(annotationsPath(filter, page, pageSize), "GET", null)
+        )
+        val serverUrl = getServerUrl().orEmpty()
+        val pending = annotationMutationQueueStore.readAll().filter { it.serverUrl == serverUrl }
+        val mappings = annotationLocalIdMappingStore.readAll()
+        overlayPendingAnnotations(responsePage, pending, mappings)
+    }
+
+    override suspend fun createAnnotation(
+        bookId: String,
+        cfi: String?,
+        bookFileId: String?,
+        text: String,
+        color: String,
+        style: String,
+        note: String?,
+        chapterTitle: String?
+    ): BookAnnotation = withContext(Dispatchers.IO) {
+        val serverUrl = getServerUrl().orEmpty()
+        if (serverUrl.isBlank()) throw AuthenticationRequiredException()
+        val localId = LOCAL_ANNOTATION_ID_PREFIX + UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        annotationMutationQueueStore.enqueue(
+            AnnotationMutationPayload(
+                annotationId = localId,
+                serverUrl = serverUrl,
+                bookId = bookId,
+                op = AnnotationMutationOp.CREATE,
+                cfi = cfi,
+                bookFileId = bookFileId,
+                text = text,
+                color = color,
+                style = style,
+                note = note,
+                chapterTitle = chapterTitle,
+                updatedAtMillis = now
+            )
+        )
+        enqueueAnnotationSyncWorker()
+        BookAnnotation(
+            id = localId,
+            bookId = bookId,
+            cfi = cfi,
+            jumpFileId = bookFileId,
+            text = text,
+            color = color,
+            style = style,
+            note = note,
+            chapterTitle = chapterTitle,
+            createdAt = Instant.ofEpochMilli(now).toString()
+        )
+    }
+
+    override suspend fun updateAnnotation(
+        bookId: String,
+        annotationId: String,
+        note: String?,
+        color: String?,
+        style: String?
+    ) = withContext(Dispatchers.IO) {
+        val serverUrl = getServerUrl().orEmpty()
+        if (serverUrl.isBlank()) throw AuthenticationRequiredException()
+        val resolvedAnnotationId = annotationLocalIdMappingStore.resolve(annotationId)
+        annotationMutationQueueStore.enqueue(
+            AnnotationMutationPayload(
+                annotationId = resolvedAnnotationId,
+                serverUrl = serverUrl,
+                bookId = bookId,
+                op = AnnotationMutationOp.UPDATE,
+                note = note,
+                noteSpecified = true,
+                color = color,
+                style = style,
+                updatedAtMillis = System.currentTimeMillis()
+            )
+        )
+        enqueueAnnotationSyncWorker()
+    }
+
+    override suspend fun deleteAnnotation(bookId: String, annotationId: String) = withContext(Dispatchers.IO) {
+        val serverUrl = getServerUrl().orEmpty()
+        if (serverUrl.isBlank()) throw AuthenticationRequiredException()
+        val resolvedAnnotationId = annotationLocalIdMappingStore.resolve(annotationId)
+        annotationMutationQueueStore.enqueue(
+            AnnotationMutationPayload(
+                annotationId = resolvedAnnotationId,
+                serverUrl = serverUrl,
+                bookId = bookId,
+                op = AnnotationMutationOp.DELETE,
+                updatedAtMillis = System.currentTimeMillis()
+            )
+        )
+        enqueueAnnotationSyncWorker()
+    }
+
+    override suspend fun pendingAnnotationMutationCount(): Int = withContext(Dispatchers.IO) {
+        annotationMutationQueueStore.countFor(getServerUrl().orEmpty())
+    }
+
+    override suspend fun syncPendingAnnotationMutations(): SyncAttemptResult = withContext(Dispatchers.IO) {
+        annotationSyncMutex.withLock {
+            val pending = annotationMutationQueueStore.readAll()
+            if (pending.isEmpty()) return@withLock SyncAttemptResult.Success
+
+            val currentServerUrl = getServerUrl().orEmpty()
+            var authBlocked = false
+            var transientFailure = false
+            pending.sortedBy { it.updatedAtMillis }.forEach { item ->
+                if (authBlocked || item.serverUrl != currentServerUrl) return@forEach
+                runCatching { postAnnotationMutation(item) }
+                    .onSuccess { result ->
+                        if (result != AnnotationMutationPostResult.DEFERRED) {
+                            annotationMutationQueueStore.acknowledge(setOf(item.annotationId))
+                        }
+                    }
+                    .onFailure { error ->
+                        when (error) {
+                            is AuthenticationRequiredException -> authBlocked = true
+                            else -> transientFailure = true
+                        }
+                    }
+                    .getOrNull()
+            }
+
+            when {
+                authBlocked -> SyncAttemptResult.AuthenticationBlocked
+                transientFailure -> SyncAttemptResult.TransientFailure
+                else -> SyncAttemptResult.Success
+            }
         }
     }
 
@@ -1792,6 +2036,43 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
         ProgressPostResult.ACCEPTED
     }
 
+    private suspend fun postAnnotationMutation(item: AnnotationMutationPayload): AnnotationMutationPostResult =
+        withContext(Dispatchers.IO) {
+            if (item.serverUrl.isBlank() || item.serverUrl != getServerUrl().orEmpty()) return@withContext AnnotationMutationPostResult.DEFERRED
+            try {
+                when (item.op) {
+                    AnnotationMutationOp.CREATE -> {
+                        val created = BookOrbitPayloadParser.parseAnnotation(
+                            request(annotationsPath(item.bookId), "POST", buildCreateAnnotationPayload(item).toString().toRequestBody(JSON))
+                        )
+                        annotationLocalIdMappingStore.remember(item.annotationId, created.id)
+                    }
+                    AnnotationMutationOp.UPDATE -> {
+                        val id = annotationLocalIdMappingStore.resolve(item.annotationId)
+                        if (id.startsWith(LOCAL_ANNOTATION_ID_PREFIX)) return@withContext AnnotationMutationPostResult.DEFERRED
+                        request(annotationPath(item.bookId, id), "PATCH", buildUpdateAnnotationPayload(item).toString().toRequestBody(JSON))
+                    }
+                    AnnotationMutationOp.DELETE -> {
+                        val id = annotationLocalIdMappingStore.resolve(item.annotationId)
+                        if (id.startsWith(LOCAL_ANNOTATION_ID_PREFIX)) return@withContext AnnotationMutationPostResult.ACCEPTED
+                        request(annotationPath(item.bookId, id), "DELETE", null)
+                    }
+                }
+                AnnotationMutationPostResult.ACCEPTED
+            } catch (error: HttpRequestException) {
+                if (error.code in 400..499) AnnotationMutationPostResult.INVALID else throw error
+            }
+        }
+
+    private fun enqueueAnnotationSyncWorker() {
+        val request = OneTimeWorkRequestBuilder<AnnotationMutationSyncWorker>()
+            .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 15, TimeUnit.SECONDS)
+            .setInitialDelay(2, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork("bookorbit-annotation-sync", ExistingWorkPolicy.KEEP, request)
+    }
+
     private fun postFileProgressWithRemap(
         item: ProgressUpdate,
         payload: JSONObject
@@ -2289,6 +2570,9 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
             path.contains("/progress") && method == "DELETE" -> "clear reading progress"
             path.contains("/progress") -> "sync reading progress"
             path.endsWith("/status") && method == "PATCH" -> "sync reading status"
+            path.contains("/annotations") && method == "POST" -> "create annotation"
+            path.contains("/annotations") && method == "PATCH" -> "update annotation"
+            path.contains("/annotations") && method == "DELETE" -> "delete annotation"
             path.contains("/books") && method == "POST" -> "load books"
             else -> "complete this request"
         }
@@ -3016,6 +3300,69 @@ internal object BookOrbitPayloadParser {
             page = root.numberValue("page")?.toInt(),
             pageSize = root.numberValue("pageSize", "size")?.toInt(),
             stats = stats
+        )
+    }
+
+    fun parseAnnotations(payload: String): BookAnnotationsPage {
+        val root = extractObject(payload, "load annotations")
+        val array = root.catalogArray("items", "annotations", "results")
+        val items = buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val id = item.stringValue("id", "_id") ?: continue
+                val bookId = item.stringValue("bookId", "book_id") ?: continue
+                add(BookAnnotation(
+                    id = id,
+                    bookId = bookId,
+                    cfi = item.stringValue("cfi"),
+                    jumpFileId = item.stringValue("jumpFileId", "jump_file_id", "fileId", "file_id"),
+                    pageno = item.numberValue("pageno", "page")?.toInt(),
+                    text = item.stringValue("text").orEmpty(),
+                    color = item.stringValue("color"),
+                    style = item.stringValue("style"),
+                    note = item.stringValue("note"),
+                    chapterTitle = item.stringValue("chapterTitle", "chapter_title"),
+                    origin = item.stringValue("origin"),
+                    positionStatus = item.stringValue("positionStatus", "position_status"),
+                    chapterIndex = item.numberValue("chapterIndex", "chapter_index")?.toInt(),
+                    createdAt = item.stringValue("createdAt", "created_at"),
+                    bookTitle = item.stringValue("bookTitle", "book_title"),
+                    author = item.stringValue("author"),
+                    deletedAt = item.stringValue("deletedAt", "deleted_at"),
+                    jumpFileFormat = item.stringValue("jumpFileFormat", "jump_file_format")
+                ))
+            }
+        }
+        return BookAnnotationsPage(items, root.numberValue("total")?.toInt(), root.numberValue("page")?.toInt(), root.numberValue("pageSize", "page_size")?.toInt())
+    }
+
+    fun parseAnnotation(payload: String): BookAnnotation {
+        val root = extractObject(payload, "save annotation")
+        val id = root.stringValue("id", "_id") ?: throw UserFacingException(
+            "The server response was missing an annotation id."
+        )
+        val bookId = root.stringValue("bookId", "book_id") ?: throw UserFacingException(
+            "The server response was missing a book id."
+        )
+        return BookAnnotation(
+            id = id,
+            bookId = bookId,
+            cfi = root.stringValue("cfi"),
+            jumpFileId = root.stringValue("jumpFileId", "jump_file_id", "fileId", "file_id"),
+            pageno = root.numberValue("pageno", "page")?.toInt(),
+            text = root.stringValue("text").orEmpty(),
+            color = root.stringValue("color"),
+            style = root.stringValue("style"),
+            note = root.stringValue("note"),
+            chapterTitle = root.stringValue("chapterTitle", "chapter_title"),
+            origin = root.stringValue("origin"),
+            positionStatus = root.stringValue("positionStatus", "position_status"),
+            chapterIndex = root.numberValue("chapterIndex", "chapter_index")?.toInt(),
+            createdAt = root.stringValue("createdAt", "created_at"),
+            bookTitle = root.stringValue("bookTitle", "book_title"),
+            author = root.stringValue("author"),
+            deletedAt = root.stringValue("deletedAt", "deleted_at"),
+            jumpFileFormat = root.stringValue("jumpFileFormat", "jump_file_format")
         )
     }
 

--- a/app/src/main/java/com/vangeaux/lagrange/Models.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/Models.kt
@@ -257,6 +257,63 @@ data class AuthorBooksPage(
     val size: Int? = null
 )
 
+data class BookAnnotation(
+    val id: String,
+    val bookId: String,
+    val cfi: String? = null,
+    val jumpFileId: String? = null,
+    val pageno: Int? = null,
+    val text: String? = null,
+    val color: String? = null,
+    val style: String? = null,
+    val note: String? = null,
+    val chapterTitle: String? = null,
+    val origin: String? = null,
+    val positionStatus: String? = null,
+    val chapterIndex: Int? = null,
+    val createdAt: String? = null,
+    val bookTitle: String? = null,
+    val author: String? = null,
+    val deletedAt: String? = null,
+    val jumpFileFormat: String? = null
+)
+
+data class AnnotationsFilter(
+    val search: String? = null,
+    val bookId: String? = null,
+    val chapter: String? = null,
+    val colors: List<String> = emptyList(),
+    val styles: List<String> = emptyList(),
+    val origins: List<String> = emptyList(),
+    val dateFrom: String? = null,
+    val dateTo: String? = null,
+    val hasNote: Boolean? = null,
+    val status: String = "active",
+    val sortBy: String = "createdAt",
+    val sortDir: String = "desc"
+)
+
+data class BookAnnotationsPage(
+    val items: List<BookAnnotation> = emptyList(),
+    val total: Int? = null,
+    val page: Int? = null,
+    val pageSize: Int? = null
+)
+
+internal fun BookAnnotation.toBookSummary(): BookSummary {
+    val format = jumpFileFormat?.takeIf { it.isNotBlank() }
+    return BookSummary(
+        libraryId = "",
+        id = bookId,
+        fileId = jumpFileId,
+        title = bookTitle ?: "Unknown book",
+        author = author,
+        format = format,
+        mediaKind = BookOrbitPayloadParser.inferMediaKind(format, bookTitle),
+        progressPageIndex = pageno?.coerceAtLeast(0)
+    )
+}
+
 enum class AchievementCatalogueStatus {
     AVAILABLE,
     UNSUPPORTED,
@@ -373,7 +430,23 @@ data class ReaderState(
     val readerPageIndex: Int = 0,
     val progressPercent: Float? = null,
     val launchMode: ReaderLaunchMode = ReaderLaunchMode.NORMAL,
-    val audioFiles: List<BookFileOption> = emptyList()
+    val audioFiles: List<BookFileOption> = emptyList(),
+    val initialCfi: String? = null,
+    val annotationText: String? = null,
+    val annotationChapterIndex: Int? = null,
+    val annotationId: String? = null,
+    val annotationColor: String? = null,
+    val annotationStyle: String? = null
+)
+
+data class ReaderOpenPosition(
+    val cfi: String? = null,
+    val pageIndex: Int? = null,
+    val text: String? = null,
+    val chapterIndex: Int? = null,
+    val annotationId: String? = null,
+    val color: String? = null,
+    val style: String? = null
 )
 
 data class ProgressUpdate(

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderActivity.kt
@@ -1,19 +1,32 @@
 package com.vangeaux.lagrange
 
 import android.app.Activity
+import android.app.AlertDialog
+import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.util.Log
+import android.view.ActionMode
 import android.view.Gravity
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
+import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.ArrayAdapter
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
@@ -37,10 +50,14 @@ import java.io.File
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import org.readium.r2.navigator.DecorableNavigator
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.Selection
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.EpubPreferences
@@ -204,6 +221,163 @@ internal data class ReadiumEpubProgressResult(
     val percent: Float?
 )
 
+internal const val DEFAULT_HIGHLIGHT_COLOR = "yellow"
+internal const val DEFAULT_HIGHLIGHT_STYLE = "highlight"
+internal const val HIGHLIGHT_DECORATION_GROUP = "bookorbit-highlights"
+
+internal data class HighlightChoice(
+    val label: String,
+    val color: String,
+    val style: String,
+    val previewColor: Int
+)
+
+internal fun epubHighlightChoices() = listOf(
+    HighlightChoice("Yellow highlight", "yellow", "highlight", 0xFFFFEB3B.toInt()),
+    HighlightChoice("Green highlight", "green", "highlight", 0xFF4CAF50.toInt()),
+    HighlightChoice("Blue highlight", "blue", "highlight", 0xFF2196F3.toInt()),
+    HighlightChoice("Pink highlight", "pink", "highlight", 0xFFE91E63.toInt()),
+    HighlightChoice("Yellow underline", "yellow", "underline", 0xFFFFEB3B.toInt())
+)
+
+internal data class EpubSelectionAction(val label: String)
+
+internal data class CapturedEpubSelection(
+    val selection: Selection,
+    val cfi: String?
+)
+
+internal fun epubSelectionActions() = listOf(
+    EpubSelectionAction("Copy"),
+    EpubSelectionAction("Share"),
+    EpubSelectionAction("Web search"),
+    EpubSelectionAction("Highlight"),
+    EpubSelectionAction("Highlight + Note")
+)
+
+internal suspend fun <T> captureSelectionBeforeAction(
+    capture: suspend () -> T?,
+    action: (T) -> Unit
+): Boolean {
+    val selection = capture() ?: return false
+    action(selection)
+    return true
+}
+
+internal fun decodeJavascriptString(value: String?): String? {
+    val encoded = value?.takeIf { it != "null" } ?: return null
+    return runCatching { org.json.JSONArray("[$encoded]").getString(0) }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+}
+
+internal fun selectedSpineIndex(
+    selectedHref: String,
+    readingOrderHrefs: List<String>
+): Int? {
+    fun normalized(value: String): String = value.substringBefore('#').substringBefore('?')
+    val selected = normalized(selectedHref)
+    return readingOrderHrefs.indexOfFirst { normalized(it) == selected }
+        .takeIf { it >= 0 }
+}
+
+internal fun combineEpubCfi(spineIndex: Int, innerRangeCfi: String?): String? {
+    if (spineIndex < 0) return null
+    val inner = innerRangeCfi
+        ?.trim()
+        ?.takeIf { it.startsWith("epubcfi(") && it.endsWith(")") }
+        ?.removePrefix("epubcfi(")
+        ?.removeSuffix(")")
+        ?: return null
+    if (inner.count { it == ',' } != 2 || !inner.startsWith('/')) return null
+    return "epubcfi(/6/${(spineIndex + 1) * 2}!$inner)"
+}
+
+internal fun epubCfiSpineIndex(cfi: String?): Int? {
+    val spineStep = Regex("^epubcfi\\(/6/(\\d+)!")
+        .find(cfi.orEmpty())
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+        ?: return null
+    if (spineStep < 2 || spineStep % 2 != 0) return null
+    return spineStep / 2 - 1
+}
+
+private val NAMED_HIGHLIGHT_COLORS = mapOf(
+    "yellow" to 0x33FFEB3B,
+    "green" to 0x334CAF50,
+    "blue" to 0x332196F3,
+    "pink" to 0x33E91E63,
+    "orange" to 0x33FF9800,
+    "purple" to 0x339C27B0
+)
+
+internal fun highlightTintForColor(color: String?): Int {
+    val value = color?.trim()?.lowercase().orEmpty()
+    NAMED_HIGHLIGHT_COLORS[value]?.let { return it }
+    if (value.startsWith("#")) {
+        runCatching { Color.parseColor(value) }.getOrNull()?.let { return it }
+    }
+    return NAMED_HIGHLIGHT_COLORS.getValue(DEFAULT_HIGHLIGHT_COLOR)
+}
+
+internal fun annotationLocatorJson(
+    cfi: String,
+    chapterHref: String,
+    text: String? = null
+): JSONObject = JSONObject().apply {
+    put("href", chapterHref)
+    put("type", MediaType.XHTML.toString())
+    put("locations", JSONObject().put("fragments", org.json.JSONArray().put(cfi)))
+    text?.takeIf { it.isNotBlank() }?.let { selectedText ->
+        put("text", JSONObject().put("highlight", selectedText))
+    }
+}
+
+internal fun resolveAnnotationChapterHref(
+    cfi: String,
+    explicitChapterIndex: Int?,
+    readingOrderHrefs: List<String>
+): String? {
+    val index = explicitChapterIndex?.takeIf { it in readingOrderHrefs.indices }
+        ?: epubCfiSpineIndex(cfi)?.takeIf { it in readingOrderHrefs.indices }
+        ?: return null
+    return readingOrderHrefs.getOrNull(index)
+}
+
+internal fun resolveInitialAnnotationLocatorJson(
+    cfi: String,
+    explicitChapterIndex: Int?,
+    text: String?,
+    readingOrderHrefs: List<String>
+): JSONObject? {
+    val href = resolveAnnotationChapterHref(cfi, explicitChapterIndex, readingOrderHrefs) ?: return null
+    return annotationLocatorJson(cfi, href, text)
+}
+
+internal fun previewAnnotationTarget(
+    annotationId: String?,
+    bookId: String?,
+    cfi: String?,
+    text: String?,
+    chapterIndex: Int?,
+    color: String?,
+    style: String?
+): BookAnnotation? {
+    val id = annotationId?.takeIf { it.isNotBlank() } ?: return null
+    val cfiValue = cfi?.takeIf { it.isNotBlank() } ?: return null
+    return BookAnnotation(
+        id = id,
+        bookId = bookId.orEmpty(),
+        cfi = cfiValue,
+        text = text,
+        chapterIndex = chapterIndex,
+        color = color,
+        style = style
+    )
+}
+
 @OptIn(ExperimentalReadiumApi::class)
 class ReadiumEpubReaderActivity : FragmentActivity() {
     private var publication: Publication? = null
@@ -223,6 +397,10 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
     private lateinit var displayTitle: String
     private lateinit var readingSessionReporter: ReadingSessionReporter
     private var isPreview: Boolean = false
+    private var bookId: String? = null
+    private val annotationRepository by lazy { BookOrbitRepository(applicationContext) }
+    private val highlightAnnotations = mutableMapOf<String, BookAnnotation>()
+    private val highlightLocators = mutableMapOf<String, Locator>()
     private var selectedTheme by mutableStateOf(EpubReaderTheme.Sepia)
     private var selectedFontFamily by mutableStateOf(EpubReaderFontFamily.PUBLISHER_DEFAULT)
     private var padding by mutableStateOf(EpubPaddingPercentages())
@@ -564,7 +742,10 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
                 readerPreferences.wordSpacing
             ),
             paginationListener = paginationListener,
-            configuration = EpubNavigatorFragment.Configuration(shouldApplyInsetsPadding = false)
+            configuration = EpubNavigatorFragment.Configuration(
+                shouldApplyInsetsPadding = false,
+                selectionActionModeCallback = if (isPreview || bookId == null) null else highlightActionModeCallback()
+            )
         )
         supportFragmentManager.fragmentFactory = fragmentFactory
         val fragment = fragmentFactory.instantiate(
@@ -584,6 +765,12 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
             )
         )
         navigator = fragment
+        if (!isPreview && bookId != null) {
+            fragment.addDecorationListener(HIGHLIGHT_DECORATION_GROUP, highlightDecorationListener)
+            loadHighlights(openedPublication)
+        } else if (isPreview) {
+            applyPreviewAnnotationDecoration(fragment, openedPublication)
+        }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 fragment.currentLocator.collect(::updateLocation)
@@ -594,7 +781,372 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
         if (!tapZoneTutorialHasShown) showTapZoneTutorial()
     }
 
+    private fun loadHighlights(openedPublication: Publication) {
+        val currentBookId = bookId ?: return
+        lifecycleScope.launch {
+            val page = runCatching {
+                annotationRepository.loadAnnotations(
+                    AnnotationsFilter(bookId = currentBookId, status = "active"),
+                    page = 1,
+                    pageSize = ANNOTATIONS_PAGE_SIZE
+                )
+            }.getOrNull() ?: return@launch
+            page.items.forEach { annotation ->
+                val locator = annotation.toLocatorOrNull(openedPublication) ?: return@forEach
+                highlightAnnotations[annotation.id] = annotation
+                highlightLocators[annotation.id] = locator
+            }
+            refreshHighlightDecorations()
+        }
+    }
+
+    private fun applyPreviewAnnotationDecoration(fragment: EpubNavigatorFragment, openedPublication: Publication) {
+        val target = previewAnnotationTarget(
+            annotationId = intent.getStringExtra(EXTRA_INITIAL_ANNOTATION_ID),
+            bookId = bookId,
+            cfi = intent.getStringExtra(EXTRA_INITIAL_CFI),
+            text = intent.getStringExtra(EXTRA_INITIAL_ANNOTATION_TEXT),
+            chapterIndex = intent.getIntExtra(EXTRA_INITIAL_ANNOTATION_CHAPTER, -1).takeIf { it >= 0 },
+            color = intent.getStringExtra(EXTRA_INITIAL_ANNOTATION_COLOR),
+            style = intent.getStringExtra(EXTRA_INITIAL_ANNOTATION_STYLE)
+        ) ?: return
+        val locator = target.toLocatorOrNull(openedPublication) ?: return
+        fragment.addDecorationListener(HIGHLIGHT_DECORATION_GROUP, highlightDecorationListener)
+        highlightAnnotations[target.id] = target
+        highlightLocators[target.id] = locator
+        lifecycleScope.launch { refreshHighlightDecorations() }
+    }
+
+    private fun BookAnnotation.toLocatorOrNull(openedPublication: Publication): Locator? {
+        val cfiValue = cfi?.takeIf { it.isNotBlank() } ?: return null
+        val link = (chapterIndex ?: epubCfiSpineIndex(cfiValue))
+            ?.let { openedPublication.readingOrder.getOrNull(it) }
+            ?: openedPublication.readingOrder.firstOrNull()
+            ?: return null
+        return runCatching {
+            Locator.fromJSON(annotationLocatorJson(cfiValue, link.url().toString(), text))
+        }.getOrNull()
+    }
+
+    private suspend fun refreshHighlightDecorations() {
+        val fragment = navigator ?: return
+        val decorations = highlightAnnotations.mapNotNull { (id, annotation) ->
+            val locator = highlightLocators[id] ?: return@mapNotNull null
+            Decoration(
+                id = id,
+                locator = locator,
+                style = when (annotation.style?.trim()?.lowercase()) {
+                    "underline" -> Decoration.Style.Underline(
+                        tint = highlightTintForColor(annotation.color),
+                        isActive = false
+                    )
+                    else -> Decoration.Style.Highlight(
+                        tint = highlightTintForColor(annotation.color),
+                        isActive = false
+                    )
+                }
+            )
+        }
+        runCatching { fragment.applyDecorations(decorations, HIGHLIGHT_DECORATION_GROUP) }
+    }
+
+    private fun highlightActionModeCallback(): ActionMode.Callback = object : ActionMode.Callback {
+        override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+            menu?.add(0, ACTION_COPY, 0, "Copy")?.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            menu?.add(0, ACTION_SHARE, 1, "Share")?.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            menu?.add(0, ACTION_WEB_SEARCH, 2, "Web search")
+            menu?.add(0, ACTION_HIGHLIGHT, 3, "Highlight")?.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+            menu?.add(0, ACTION_HIGHLIGHT_WITH_NOTE, 4, "Highlight + Note")
+            return true
+        }
+
+        override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean = false
+
+        override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+            val action = item?.itemId ?: return false
+            if (action !in SELECTION_ACTIONS) return false
+            captureCurrentSelection(
+                mode = mode,
+                requireCfi = action == ACTION_HIGHLIGHT || action == ACTION_HIGHLIGHT_WITH_NOTE
+            ) { selection ->
+                when (action) {
+                    ACTION_COPY -> copySelection(selection)
+                    ACTION_SHARE -> shareSelection(selection)
+                    ACTION_WEB_SEARCH -> searchSelection(selection)
+                    ACTION_HIGHLIGHT -> showHighlightChoiceDialog(selection, note = null)
+                    ACTION_HIGHLIGHT_WITH_NOTE -> promptForNote(existingNote = null) { note ->
+                        showHighlightChoiceDialog(selection, note)
+                    }
+                }
+            }
+            return true
+        }
+
+        override fun onDestroyActionMode(mode: ActionMode?) = Unit
+    }
+
+    private fun captureCurrentSelection(
+        mode: ActionMode?,
+        requireCfi: Boolean,
+        action: (CapturedEpubSelection) -> Unit
+    ) {
+        val fragment = navigator ?: return
+        lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            val captured = runCatching {
+                captureSelectionBeforeAction(
+                    capture = {
+                        val selection = fragment.currentSelection()
+                            ?: return@captureSelectionBeforeAction null
+                        val cfi = if (requireCfi) generateSelectionCfi(fragment, selection) else null
+                        if (requireCfi && cfi == null) return@captureSelectionBeforeAction null
+                        CapturedEpubSelection(selection, cfi)
+                    },
+                    action = action
+                )
+            }.getOrElse { error ->
+                Log.e(TAG, "Could not capture the EPUB text selection.", error)
+                false
+            }
+            if (!captured) {
+                Toast.makeText(
+                    this@ReadiumEpubReaderActivity,
+                    if (requireCfi) {
+                        "This text selection cannot be highlighted. Please try selecting it again."
+                    } else {
+                        "The selected text is no longer available. Please select it again."
+                    },
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            mode?.finish()
+        }
+    }
+
+    private suspend fun generateSelectionCfi(
+        fragment: EpubNavigatorFragment,
+        selection: Selection
+    ): String? {
+        val openedPublication = publication ?: return null
+        val spineIndex = selectedSpineIndex(
+            selectedHref = selection.locator.href.toString(),
+            readingOrderHrefs = openedPublication.readingOrder.map { it.url().toString() }
+        ) ?: return null
+        val script = assets.open(FOLIATE_SELECTION_CFI_ASSET).bufferedReader().use { it.readText() }
+        val innerCfi = decodeJavascriptString(fragment.evaluateJavascript(script))
+        return combineEpubCfi(spineIndex, innerCfi)
+    }
+
+    private fun selectedText(selection: Selection): String? =
+        selection.locator.text.highlight?.takeIf { it.isNotBlank() }
+
+    private fun copySelection(captured: CapturedEpubSelection) {
+        val selection = captured.selection
+        val text = selectedText(selection) ?: return
+        getSystemService(ClipboardManager::class.java)
+            ?.setPrimaryClip(ClipData.newPlainText("Selected text", text))
+        Toast.makeText(this, "Copied", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun shareSelection(captured: CapturedEpubSelection) {
+        val selection = captured.selection
+        val text = selectedText(selection) ?: return
+        startActivity(
+            Intent.createChooser(
+                Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_TEXT, text)
+                },
+                "Share selected text"
+            )
+        )
+    }
+
+    private fun searchSelection(captured: CapturedEpubSelection) {
+        val selection = captured.selection
+        val text = selectedText(selection) ?: return
+        runCatching {
+            startActivity(Intent(Intent.ACTION_WEB_SEARCH).putExtra(SearchManager.QUERY, text))
+        }.onFailure {
+            Toast.makeText(this, "No web search app is available.", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun showHighlightChoiceDialog(selection: CapturedEpubSelection, note: String?) {
+        if (isFinishing || isDestroyed) return
+        val choices = epubHighlightChoices()
+        val adapter = object : ArrayAdapter<HighlightChoice>(
+            this,
+            android.R.layout.simple_list_item_1,
+            choices
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val view = super.getView(position, convertView, parent) as TextView
+                val choice = getItem(position) ?: return view
+                view.text = choice.label
+                view.setPadding(dpToPx(20), view.paddingTop, dpToPx(20), view.paddingBottom)
+                val swatch = if (choice.style == "underline") {
+                    ColorDrawable(choice.previewColor).apply {
+                        setBounds(0, 0, dpToPx(32), dpToPx(4))
+                    }
+                } else {
+                    GradientDrawable().apply {
+                        shape = GradientDrawable.RECTANGLE
+                        cornerRadius = dpToPx(4).toFloat()
+                        setColor(choice.previewColor)
+                        setBounds(0, 0, dpToPx(32), dpToPx(20))
+                    }
+                }
+                view.setCompoundDrawables(swatch, null, null, null)
+                view.compoundDrawablePadding = dpToPx(16)
+                return view
+            }
+        }
+        AlertDialog.Builder(this)
+            .setTitle("Highlight style")
+            .setAdapter(adapter) { _, which ->
+                choices.getOrNull(which)?.let { choice ->
+                    createHighlightFromSelection(
+                        selection = selection,
+                        note = note,
+                        color = choice.color,
+                        style = choice.style
+                    )
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun createHighlightFromSelection(
+        selection: CapturedEpubSelection,
+        note: String?,
+        color: String = DEFAULT_HIGHLIGHT_COLOR,
+        style: String = DEFAULT_HIGHLIGHT_STYLE
+    ) {
+        val currentBookId = bookId ?: return
+        lifecycleScope.launch {
+            val cfiValue = selection.cfi
+            val text = selection.selection.locator.text.highlight?.takeIf { it.isNotBlank() }
+            if (cfiValue.isNullOrBlank() || text == null) {
+                Log.w(TAG, "The captured EPUB selection did not produce text and a range CFI.")
+                Toast.makeText(
+                    this@ReadiumEpubReaderActivity,
+                    "This text selection cannot be highlighted. Please try selecting it again.",
+                    Toast.LENGTH_LONG
+                ).show()
+                return@launch
+            }
+            val annotation = runCatching {
+                annotationRepository.createAnnotation(
+                    bookId = currentBookId,
+                    cfi = cfiValue,
+                    bookFileId = intent.getStringExtra(EXTRA_FILE_ID),
+                    text = text,
+                    color = color,
+                    style = style,
+                    note = note,
+                    chapterTitle = chapterTitles.getOrNull(currentChapter)
+                )
+            }.onFailure { error ->
+                Log.e(TAG, "Could not create the EPUB annotation.", error)
+            }.getOrNull()
+            if (annotation == null) {
+                Toast.makeText(
+                    this@ReadiumEpubReaderActivity,
+                    "The highlight could not be saved.",
+                    Toast.LENGTH_LONG
+                ).show()
+                return@launch
+            }
+            highlightAnnotations[annotation.id] = annotation
+            highlightLocators[annotation.id] = selection.selection.locator.copyWithLocations(
+                fragments = listOf(cfiValue)
+            )
+            navigator?.clearSelection()
+            refreshHighlightDecorations()
+        }
+    }
+
+    private val highlightDecorationListener = object : DecorableNavigator.Listener {
+        override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+            val annotation = highlightAnnotations[event.decoration.id] ?: return false
+            showHighlightActionsDialog(annotation)
+            return true
+        }
+    }
+
+    private fun showHighlightActionsDialog(annotation: BookAnnotation) {
+        if (isFinishing || isDestroyed) return
+        AlertDialog.Builder(this)
+            .setTitle(if (annotation.note.isNullOrBlank()) "Highlight" else "Highlight note")
+            .setItems(arrayOf("Edit note", "Delete highlight", "Cancel")) { _, which ->
+                when (which) {
+                    0 -> promptForNote(existingNote = annotation.note) { note -> updateHighlightNote(annotation, note) }
+                    1 -> deleteHighlight(annotation)
+                }
+            }
+            .show()
+    }
+
+    private fun promptForNote(existingNote: String?, onSave: (String?) -> Unit) {
+        if (isFinishing || isDestroyed) return
+        val input = EditText(this).apply { setText(existingNote.orEmpty()) }
+        AlertDialog.Builder(this)
+            .setTitle("Note")
+            .setView(input)
+            .setPositiveButton("Save") { _, _ ->
+                onSave(input.text?.toString()?.trim()?.takeIf { it.isNotBlank() })
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun updateHighlightNote(annotation: BookAnnotation, note: String?) {
+        val currentBookId = bookId ?: return
+        lifecycleScope.launch {
+            val succeeded = runCatching {
+                annotationRepository.updateAnnotation(
+                    bookId = currentBookId,
+                    annotationId = annotation.id,
+                    note = note,
+                    color = annotation.color,
+                    style = annotation.style
+                )
+            }.isSuccess
+            if (succeeded) {
+                highlightAnnotations[annotation.id] = annotation.copy(note = note)
+            }
+        }
+    }
+
+    private fun deleteHighlight(annotation: BookAnnotation) {
+        val currentBookId = bookId ?: return
+        lifecycleScope.launch {
+            val succeeded = runCatching {
+                annotationRepository.deleteAnnotation(currentBookId, annotation.id)
+            }.isSuccess
+            if (succeeded) {
+                highlightAnnotations.remove(annotation.id)
+                highlightLocators.remove(annotation.id)
+                refreshHighlightDecorations()
+            }
+        }
+    }
+
     private fun initialLocator(openedPublication: Publication): Locator {
+        intent.getStringExtra(EXTRA_INITIAL_CFI)?.takeIf { it.isNotBlank() }?.let { cfi ->
+            val explicitChapterIndex = intent.getIntExtra(EXTRA_INITIAL_ANNOTATION_CHAPTER, -1)
+                .takeIf { it >= 0 }
+            val json = resolveInitialAnnotationLocatorJson(
+                cfi = cfi,
+                explicitChapterIndex = explicitChapterIndex,
+                text = intent.getStringExtra(EXTRA_INITIAL_ANNOTATION_TEXT),
+                readingOrderHrefs = openedPublication.readingOrder.map { it.url().toString() }
+            )
+            if (json != null) {
+                runCatching { Locator.fromJSON(json) }.getOrNull()?.let { return it }
+            }
+        }
         if (!isPreview) {
             locatorStore.read(readerKey)?.let { stored ->
                 if (openedPublication.readingOrder.any { link ->
@@ -930,21 +1482,43 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
         private const val EXTRA_READER_KEY = "readium_epub_reader_key"
         private const val EXTRA_LIBRARY_ID = "readium_epub_library_id"
         private const val EXTRA_FILE_ID = "readium_epub_file_id"
+        private const val EXTRA_BOOK_ID = "readium_epub_book_id"
         private const val EXTRA_IS_PREVIEW = "readium_epub_is_preview"
         private const val EXTRA_INITIAL_CHAPTER = "readium_epub_initial_chapter"
         private const val EXTRA_INITIAL_PAGE = "readium_epub_initial_page"
         private const val EXTRA_INITIAL_PAGE_COUNT = "readium_epub_initial_page_count"
         private const val EXTRA_INITIAL_PERCENT = "readium_epub_initial_percent"
+        private const val EXTRA_INITIAL_CFI = "readium_epub_initial_cfi"
+        private const val EXTRA_INITIAL_ANNOTATION_TEXT = "readium_epub_initial_annotation_text"
+        private const val EXTRA_INITIAL_ANNOTATION_CHAPTER = "readium_epub_initial_annotation_chapter"
+        private const val EXTRA_INITIAL_ANNOTATION_ID = "readium_epub_initial_annotation_id"
+        private const val EXTRA_INITIAL_ANNOTATION_COLOR = "readium_epub_initial_annotation_color"
+        private const val EXTRA_INITIAL_ANNOTATION_STYLE = "readium_epub_initial_annotation_style"
         private const val EXTRA_RESULT_CHAPTER = "readium_epub_result_chapter"
         private const val EXTRA_RESULT_PAGE = "readium_epub_result_page"
         private const val EXTRA_RESULT_PAGE_COUNT = "readium_epub_result_page_count"
         private const val EXTRA_RESULT_PERCENT = "readium_epub_result_percent"
         private const val NAVIGATOR_TAG = "readium_epub_navigator"
+        private const val TAG = "ReadiumEpubReader"
+        private const val FOLIATE_SELECTION_CFI_ASSET = "foliate-selection-cfi.js"
+        private const val ACTION_COPY = 1000
+        private const val ACTION_HIGHLIGHT = 1001
+        private const val ACTION_HIGHLIGHT_WITH_NOTE = 1002
+        private const val ACTION_SHARE = 1003
+        private const val ACTION_WEB_SEARCH = 1004
+        private val SELECTION_ACTIONS = setOf(
+            ACTION_COPY,
+            ACTION_SHARE,
+            ACTION_WEB_SEARCH,
+            ACTION_HIGHLIGHT,
+            ACTION_HIGHLIGHT_WITH_NOTE
+        )
 
         fun createIntent(
             context: Context,
             file: File,
             fileId: String? = null,
+            bookId: String? = null,
             title: String,
             readerKey: String,
             libraryId: String = "",
@@ -952,10 +1526,17 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
             initialChapter: Int,
             initialPage: Int,
             initialPageCount: Int,
-            initialPercent: Float?
+            initialPercent: Float?,
+            initialCfi: String? = null,
+            initialAnnotationText: String? = null,
+            initialAnnotationChapterIndex: Int? = null,
+            initialAnnotationId: String? = null,
+            initialAnnotationColor: String? = null,
+            initialAnnotationStyle: String? = null
         ): Intent = Intent(context, ReadiumEpubReaderActivity::class.java)
             .putExtra(EXTRA_FILE_PATH, file.absolutePath)
             .putExtra(EXTRA_FILE_ID, fileId)
+            .putExtra(EXTRA_BOOK_ID, bookId)
             .putExtra(EXTRA_TITLE, title)
             .putExtra(EXTRA_READER_KEY, readerKey)
             .putExtra(EXTRA_LIBRARY_ID, libraryId)
@@ -965,6 +1546,12 @@ class ReadiumEpubReaderActivity : FragmentActivity() {
             .putExtra(EXTRA_INITIAL_PAGE_COUNT, initialPageCount)
             .apply {
                 initialPercent?.let { putExtra(EXTRA_INITIAL_PERCENT, it) }
+                initialCfi?.let { putExtra(EXTRA_INITIAL_CFI, it) }
+                initialAnnotationText?.let { putExtra(EXTRA_INITIAL_ANNOTATION_TEXT, it) }
+                initialAnnotationChapterIndex?.let { putExtra(EXTRA_INITIAL_ANNOTATION_CHAPTER, it) }
+                initialAnnotationId?.let { putExtra(EXTRA_INITIAL_ANNOTATION_ID, it) }
+                initialAnnotationColor?.let { putExtra(EXTRA_INITIAL_ANNOTATION_COLOR, it) }
+                initialAnnotationStyle?.let { putExtra(EXTRA_INITIAL_ANNOTATION_STYLE, it) }
             }
 
         internal fun readProgressResult(data: Intent?): ReadiumEpubProgressResult? {

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderLauncher.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumEpubReaderLauncher.kt
@@ -24,6 +24,7 @@ internal fun shouldUseReadiumEpubReader(mediaKind: MediaKind): Boolean =
 internal fun ReadiumEpubReaderLauncher(
     file: File,
     fileId: String? = null,
+    bookId: String? = null,
     title: String,
     readerKey: String,
     libraryId: String,
@@ -32,6 +33,12 @@ internal fun ReadiumEpubReaderLauncher(
     initialPage: Int,
     initialPageCount: Int,
     initialPercent: Float?,
+    initialCfi: String? = null,
+    initialAnnotationText: String? = null,
+    initialAnnotationChapterIndex: Int? = null,
+    initialAnnotationId: String? = null,
+    initialAnnotationColor: String? = null,
+    initialAnnotationStyle: String? = null,
     onProgress: (chapterIndex: Int, pageIndex: Int, pageCount: Int, percent: Float?) -> Unit,
     onFinished: () -> Unit
 ) {
@@ -67,6 +74,7 @@ internal fun ReadiumEpubReaderLauncher(
                     context = context,
                     file = file,
                     fileId = fileId,
+                    bookId = bookId,
                     title = title,
                     readerKey = readerKey,
                     libraryId = libraryId,
@@ -74,7 +82,13 @@ internal fun ReadiumEpubReaderLauncher(
                     initialChapter = initialChapter,
                     initialPage = initialPage,
                     initialPageCount = initialPageCount,
-                    initialPercent = initialPercent
+                    initialPercent = initialPercent,
+                    initialCfi = initialCfi,
+                    initialAnnotationText = initialAnnotationText,
+                    initialAnnotationChapterIndex = initialAnnotationChapterIndex,
+                    initialAnnotationId = initialAnnotationId,
+                    initialAnnotationColor = initialAnnotationColor,
+                    initialAnnotationStyle = initialAnnotationStyle
                 )
             )
         }

--- a/app/src/test/java/com/vangeaux/lagrange/AnnotationMutationQueueStoreTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AnnotationMutationQueueStoreTest.kt
@@ -1,0 +1,149 @@
+package com.vangeaux.lagrange
+
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnnotationMutationQueueStoreTest {
+    @Test
+    fun `stores distinct mutations for different annotations`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-queue").toFile())
+
+        store.enqueue(create("local:a", updatedAtMillis = 10L))
+        store.enqueue(create("local:b", updatedAtMillis = 20L))
+
+        assertEquals(listOf("local:a", "local:b"), store.readAll().map { it.annotationId })
+    }
+
+    @Test
+    fun `update after a pending create collapses into one create entry`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-collapse-update").toFile())
+
+        store.enqueue(create("local:a", text = "original", updatedAtMillis = 10L))
+        store.enqueue(update("local:a", note = "remember this", updatedAtMillis = 20L))
+
+        val pending = store.readAll()
+        assertEquals(1, pending.size)
+        assertEquals(AnnotationMutationOp.CREATE, pending.single().op)
+        assertEquals("original", pending.single().text)
+        assertEquals("remember this", pending.single().note)
+        assertTrue(pending.single().noteSpecified)
+        assertEquals(20L, pending.single().updatedAtMillis)
+    }
+
+    @Test
+    fun `delete of a pending create cancels the create entirely`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-collapse-delete").toFile())
+
+        store.enqueue(create("local:a", updatedAtMillis = 10L))
+        store.enqueue(delete("local:a", updatedAtMillis = 20L))
+
+        assertTrue(store.readAll().isEmpty())
+    }
+
+    @Test
+    fun `delete of an already synced annotation replaces a queued update`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-collapse-update-delete").toFile())
+
+        store.enqueue(update("server-42", updatedAtMillis = 10L))
+        store.enqueue(delete("server-42", updatedAtMillis = 20L))
+
+        val pending = store.readAll()
+        assertEquals(1, pending.size)
+        assertEquals(AnnotationMutationOp.DELETE, pending.single().op)
+    }
+
+    @Test
+    fun `acknowledging an id removes only that entry`() = runBlocking {
+        val filesDir = Files.createTempDirectory("annotation-ack").toFile()
+        val syncingStore = AnnotationMutationQueueStore(filesDir)
+        val editorStore = AnnotationMutationQueueStore(filesDir)
+
+        syncingStore.enqueue(create("local:a", updatedAtMillis = 10L))
+        editorStore.enqueue(create("local:b", updatedAtMillis = 20L))
+        syncingStore.acknowledge(setOf("local:a"))
+
+        assertEquals(listOf("local:b"), editorStore.readAll().map { it.annotationId })
+    }
+
+    @Test
+    fun `counts and clears only the requested server`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-server").toFile())
+        store.enqueue(create("local:a", updatedAtMillis = 10L))
+        store.enqueue(create("local:b", serverUrl = "https://other.example", updatedAtMillis = 20L))
+
+        assertEquals(1, store.countFor("https://example.test"))
+        assertEquals(1, store.countFor("https://other.example"))
+
+        store.clearServer("https://example.test")
+
+        assertEquals(listOf("local:b"), store.readAll().map { it.annotationId })
+    }
+
+    @Test
+    fun `mapping store survives a new instance`() = runBlocking {
+        val filesDir = Files.createTempDirectory("annotation-mapping").toFile()
+        AnnotationLocalIdMappingStore(filesDir).remember("local:a", "server-1")
+
+        assertEquals("server-1", AnnotationLocalIdMappingStore(filesDir).resolve("local:a"))
+    }
+
+    @Test
+    fun `pending update can explicitly clear a note`() = runBlocking {
+        val store = AnnotationMutationQueueStore(Files.createTempDirectory("annotation-clear-note").toFile())
+        store.enqueue(create("local:a", updatedAtMillis = 10L).copy(note = "old", noteSpecified = true))
+        store.enqueue(update("local:a", note = null, updatedAtMillis = 20L))
+
+        val pending = store.readAll().single()
+        assertTrue(pending.noteSpecified)
+        assertEquals(null, pending.note)
+    }
+
+    private fun create(
+        annotationId: String,
+        serverUrl: String = "https://example.test",
+        text: String = "hello",
+        updatedAtMillis: Long
+    ) = AnnotationMutationPayload(
+        annotationId = annotationId,
+        serverUrl = serverUrl,
+        bookId = "book-1",
+        op = AnnotationMutationOp.CREATE,
+        cfi = "epubcfi(/6/2)",
+        text = text,
+        color = "yellow",
+        style = "highlight",
+        updatedAtMillis = updatedAtMillis
+    )
+
+    private fun update(
+        annotationId: String,
+        serverUrl: String = "https://example.test",
+        note: String? = null,
+        updatedAtMillis: Long
+    ) = AnnotationMutationPayload(
+        annotationId = annotationId,
+        serverUrl = serverUrl,
+        bookId = "book-1",
+        op = AnnotationMutationOp.UPDATE,
+        note = note,
+        noteSpecified = true,
+        color = "yellow",
+        style = "highlight",
+        updatedAtMillis = updatedAtMillis
+    )
+
+    private fun delete(
+        annotationId: String,
+        serverUrl: String = "https://example.test",
+        updatedAtMillis: Long
+    ) = AnnotationMutationPayload(
+        annotationId = annotationId,
+        serverUrl = serverUrl,
+        bookId = "book-1",
+        op = AnnotationMutationOp.DELETE,
+        updatedAtMillis = updatedAtMillis
+    )
+}

--- a/app/src/test/java/com/vangeaux/lagrange/BookOrbitPayloadParserTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/BookOrbitPayloadParserTest.kt
@@ -7,6 +7,178 @@ import org.junit.Test
 
 class BookOrbitPayloadParserTest {
     @Test
+    fun annotationBookSummaryPreservesBookAndFileIdentity() {
+        val annotation = BookAnnotation(
+            id = "a1",
+            bookId = "b1",
+            jumpFileId = "f1",
+            jumpFileFormat = "pdf",
+            bookTitle = "Book",
+            author = "Author"
+        )
+
+        val book = annotation.toBookSummary()
+
+        assertEquals("b1", book.id)
+        assertEquals("f1", book.fileId)
+        assertEquals(MediaKind.PDF, book.mediaKind)
+        assertEquals("Book", book.title)
+    }
+
+    @Test
+    fun parsesAnnotationHubItemsAndPaging() {
+        val result = BookOrbitPayloadParser.parseAnnotations("""
+            {"items":[{"id":"a1","bookId":"b1","text":"hello","note":"remember","cfi":"epubcfi(/6/2)","jumpFileId":"f1","pageno":4,"bookTitle":"Book","author":"Author"}],"total":1,"page":1,"pageSize":30}
+        """.trimIndent())
+
+        assertEquals(1, result.total)
+        assertEquals("a1", result.items.single().id)
+        assertEquals("hello", result.items.single().text)
+        assertEquals("f1", result.items.single().jumpFileId)
+        assertEquals(4, result.items.single().pageno)
+    }
+
+    @Test
+    fun parsesCreatedAnnotationResponse() {
+        val result = BookOrbitPayloadParser.parseAnnotation(
+            """{"id":"a1","bookId":"b1","cfi":"epubcfi(/6/2)","text":"hello","color":"yellow","style":"highlight"}"""
+        )
+
+        assertEquals("a1", result.id)
+        assertEquals("b1", result.bookId)
+        assertEquals("hello", result.text)
+        assertEquals("yellow", result.color)
+    }
+
+    @Test
+    fun annotationsPathEncodesBookId() {
+        assertEquals("/api/v1/books/book%20one/annotations", annotationsPath("book one"))
+    }
+
+    @Test
+    fun annotationPathEncodesBookAndAnnotationId() {
+        assertEquals(
+            "/api/v1/books/book%20one/annotations/local%3Aabc",
+            annotationPath("book one", "local:abc")
+        )
+    }
+
+    @Test
+    fun buildCreateAnnotationPayloadIncludesRequiredFieldsAndOmitsBlankBookFileId() {
+        val payload = buildCreateAnnotationPayload(
+            AnnotationMutationPayload(
+                annotationId = "local:a",
+                bookId = "b1",
+                op = AnnotationMutationOp.CREATE,
+                cfi = "epubcfi(/6/2)",
+                bookFileId = "42",
+                text = "hello",
+                color = "yellow",
+                style = "highlight",
+                note = "remember",
+                chapterTitle = "Chapter 1"
+            )
+        )
+
+        assertEquals("epubcfi(/6/2)", payload.getString("cfi"))
+        assertEquals(42, payload.getInt("bookFileId"))
+        assertEquals("hello", payload.getString("text"))
+        assertEquals("yellow", payload.getString("color"))
+        assertEquals("highlight", payload.getString("style"))
+        assertEquals("remember", payload.getString("note"))
+        assertEquals("Chapter 1", payload.getString("chapterTitle"))
+    }
+
+    @Test
+    fun buildCreateAnnotationPayloadOmitsNonNumericBookFileId() {
+        val payload = buildCreateAnnotationPayload(
+            AnnotationMutationPayload(
+                annotationId = "local:a",
+                bookId = "b1",
+                op = AnnotationMutationOp.CREATE,
+                bookFileId = "not-a-number",
+                text = "hello",
+                color = "yellow",
+                style = "highlight"
+            )
+        )
+
+        assertTrue(!payload.has("bookFileId"))
+    }
+
+    @Test
+    fun buildUpdateAnnotationPayloadOmitsUnsetFields() {
+        val payload = buildUpdateAnnotationPayload(
+            AnnotationMutationPayload(
+                annotationId = "server-1",
+                bookId = "b1",
+                op = AnnotationMutationOp.UPDATE,
+                note = "updated note",
+                noteSpecified = true
+            )
+        )
+
+        assertEquals("updated note", payload.getString("note"))
+        assertTrue(!payload.has("color"))
+        assertTrue(!payload.has("style"))
+    }
+
+    @Test
+    fun `pending annotation overlay masks deletes and applies updates`() {
+        val page = BookAnnotationsPage(
+            items = listOf(
+                BookAnnotation("server-1", "b1", text = "old", color = "yellow", style = "highlight"),
+                BookAnnotation("server-2", "b1", text = "remove")
+            )
+        )
+        val result = overlayPendingAnnotations(
+            page,
+            listOf(
+                AnnotationMutationPayload(
+                    annotationId = "server-1",
+                    bookId = "b1",
+                    op = AnnotationMutationOp.UPDATE,
+                    note = "new note",
+                    noteSpecified = true,
+                    color = "blue",
+                    updatedAtMillis = 2L
+                ),
+                AnnotationMutationPayload(
+                    annotationId = "server-2",
+                    bookId = "b1",
+                    op = AnnotationMutationOp.DELETE,
+                    updatedAtMillis = 3L
+                )
+            ),
+            emptyMap()
+        )
+
+        assertEquals(1, result.items.size)
+        assertEquals("new note", result.items.single().note)
+        assertEquals("blue", result.items.single().color)
+    }
+
+    @Test
+    fun `pending create is visible with local id until server hydration catches up`() {
+        val result = overlayPendingAnnotations(
+            BookAnnotationsPage(),
+            listOf(
+                AnnotationMutationPayload(
+                    annotationId = "local:a",
+                    bookId = "b1",
+                    op = AnnotationMutationOp.CREATE,
+                    cfi = "epubcfi(/6/2)",
+                    text = "new",
+                    updatedAtMillis = 4L
+                )
+            ),
+            emptyMap()
+        )
+
+        assertEquals("local:a", result.items.single().id)
+        assertEquals("new", result.items.single().text)
+    }
+    @Test
     fun `parseLibraries retains square covers and defaults unknown values to portrait`() {
         val libraries = BookOrbitPayloadParser.parseLibraries(
             """

--- a/app/src/test/java/com/vangeaux/lagrange/EpubAnnotationSelectionTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/EpubAnnotationSelectionTest.kt
@@ -1,0 +1,264 @@
+package com.vangeaux.lagrange
+
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EpubAnnotationSelectionTest {
+    @Test
+    fun `selection is captured before annotation UI opens`() = runBlocking {
+        val events = mutableListOf<String>()
+
+        val captured = captureSelectionBeforeAction(
+            capture = {
+                events += "capture"
+                "selection"
+            },
+            action = {
+                events += "dialog:$it"
+            }
+        )
+
+        assertTrue(captured)
+        assertEquals(listOf("capture", "dialog:selection"), events)
+    }
+
+    @Test
+    fun `annotation UI does not open when selection capture fails`() = runBlocking {
+        var opened = false
+
+        val captured = captureSelectionBeforeAction<String>(
+            capture = { null },
+            action = { opened = true }
+        )
+
+        assertFalse(captured)
+        assertFalse(opened)
+    }
+
+    @Test
+    fun `selection menu retains common phone actions and annotation actions`() {
+        assertEquals(
+            listOf("Copy", "Share", "Web search", "Highlight", "Highlight + Note"),
+            epubSelectionActions().map { it.label }
+        )
+    }
+
+    @Test
+    fun `highlight choices expose visual swatch colors and style`() {
+        val choices = epubHighlightChoices()
+
+        assertEquals(listOf("yellow", "green", "blue", "pink", "yellow"), choices.map { it.color })
+        assertEquals(listOf("highlight", "highlight", "highlight", "highlight", "underline"), choices.map { it.style })
+        assertTrue(choices.all { (it.previewColor ushr 24) == 0xFF })
+    }
+
+    @Test
+    fun `full epub cfi combines selected spine item with foliate range`() {
+        assertEquals(
+            "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+            combineEpubCfi(
+                spineIndex = 2,
+                innerRangeCfi = "epubcfi(/4/2,/1:3,/1:9)"
+            )
+        )
+    }
+
+    @Test
+    fun `full epub cfi rejects non-range and malformed generator values`() {
+        assertEquals(null, combineEpubCfi(0, "epubcfi(/4/2/1:3)"))
+        assertEquals(null, combineEpubCfi(0, "null"))
+        assertEquals(null, combineEpubCfi(-1, "epubcfi(/4,/1:3,/1:9)"))
+    }
+
+    @Test
+    fun `webview cfi result decodes a JSON encoded javascript string`() {
+        val encoded = JSONObject.quote("epubcfi(/4/2,/1:3,/1:9)")
+
+        assertEquals(
+            "epubcfi(/4/2,/1:3,/1:9)",
+            decodeJavascriptString(encoded)
+        )
+        assertEquals(null, decodeJavascriptString("null"))
+    }
+
+    @Test
+    fun `selected resource lookup ignores query and fragment suffixes`() {
+        assertEquals(
+            1,
+            selectedSpineIndex(
+                selectedHref = "OPS/chapter-2.xhtml#paragraph-4",
+                readingOrderHrefs = listOf("OPS/chapter-1.xhtml", "OPS/chapter-2.xhtml")
+            )
+        )
+        assertEquals(null, selectedSpineIndex("OPS/missing.xhtml", listOf("OPS/chapter-1.xhtml")))
+    }
+
+    @Test
+    fun `spine index is recovered from a complete epub cfi`() {
+        assertEquals(2, epubCfiSpineIndex("epubcfi(/6/6!/4/2,/1:3,/1:9)"))
+        assertEquals(null, epubCfiSpineIndex("epubcfi(/4/2,/1:3,/1:9)"))
+        assertEquals(null, epubCfiSpineIndex("not-a-cfi"))
+    }
+
+    @Test
+    fun `restored annotation locator includes text quote for readium decoration anchoring`() {
+        val json = annotationLocatorJson(
+            cfi = "epubcfi(/6/2!/4/2,/1:3,/1:9)",
+            chapterHref = "OPS/chapter.xhtml",
+            text = "selected words"
+        )
+
+        assertEquals("selected words", json.getJSONObject("text").getString("highlight"))
+    }
+
+    @Test
+    fun `annotation chapter href is derived from the cfi spine index when no explicit chapter is given`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml", "OPS/chapter-2.xhtml", "OPS/chapter-3.xhtml")
+
+        assertEquals(
+            "OPS/chapter-3.xhtml",
+            resolveAnnotationChapterHref(
+                cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+                explicitChapterIndex = null,
+                readingOrderHrefs = hrefs
+            )
+        )
+    }
+
+    @Test
+    fun `explicit annotation chapter index takes precedence over the cfi derived index`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml", "OPS/chapter-2.xhtml", "OPS/chapter-3.xhtml")
+
+        assertEquals(
+            "OPS/chapter-2.xhtml",
+            resolveAnnotationChapterHref(
+                cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+                explicitChapterIndex = 1,
+                readingOrderHrefs = hrefs
+            )
+        )
+    }
+
+    @Test
+    fun `annotation chapter href resolution falls back to the cfi when the explicit chapter index is out of range`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml", "OPS/chapter-2.xhtml", "OPS/chapter-3.xhtml")
+
+        assertEquals(
+            "OPS/chapter-3.xhtml",
+            resolveAnnotationChapterHref(
+                cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+                explicitChapterIndex = 99,
+                readingOrderHrefs = hrefs
+            )
+        )
+    }
+
+    @Test
+    fun `annotation chapter href resolution returns null for a malformed or out of range cfi`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml")
+
+        assertEquals(
+            null,
+            resolveAnnotationChapterHref(
+                cfi = "not-a-cfi",
+                explicitChapterIndex = null,
+                readingOrderHrefs = hrefs
+            )
+        )
+        assertEquals(
+            null,
+            resolveAnnotationChapterHref(
+                cfi = "epubcfi(/6/40!/4/2,/1:3,/1:9)",
+                explicitChapterIndex = null,
+                readingOrderHrefs = hrefs
+            )
+        )
+    }
+
+    @Test
+    fun `initial annotation locator json resolves the cfi derived href and includes the selected text`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml", "OPS/chapter-2.xhtml", "OPS/chapter-3.xhtml")
+
+        val json = resolveInitialAnnotationLocatorJson(
+            cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+            explicitChapterIndex = null,
+            text = "selected words",
+            readingOrderHrefs = hrefs
+        )
+
+        assertEquals("OPS/chapter-3.xhtml", json?.getString("href"))
+        assertEquals("selected words", json?.getJSONObject("text")?.getString("highlight"))
+    }
+
+    @Test
+    fun `initial annotation locator json returns null for a malformed or out of range cfi`() {
+        val hrefs = listOf("OPS/chapter-1.xhtml")
+
+        assertEquals(
+            null,
+            resolveInitialAnnotationLocatorJson(
+                cfi = "not-a-cfi",
+                explicitChapterIndex = null,
+                text = null,
+                readingOrderHrefs = hrefs
+            )
+        )
+    }
+
+    @Test
+    fun `preview annotation target renders only the tapped annotation`() {
+        val target = previewAnnotationTarget(
+            annotationId = "annotation-1",
+            bookId = "book-1",
+            cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+            text = "selected words",
+            chapterIndex = 2,
+            color = "yellow",
+            style = "highlight"
+        )
+
+        assertEquals("annotation-1", target?.id)
+        assertEquals("book-1", target?.bookId)
+        assertEquals("epubcfi(/6/6!/4/2,/1:3,/1:9)", target?.cfi)
+        assertEquals("selected words", target?.text)
+        assertEquals(2, target?.chapterIndex)
+        assertEquals("yellow", target?.color)
+        assertEquals("highlight", target?.style)
+    }
+
+    @Test
+    fun `preview annotation target returns none for ordinary preview without a tapped annotation`() {
+        assertEquals(
+            null,
+            previewAnnotationTarget(
+                annotationId = null,
+                bookId = "book-1",
+                cfi = "epubcfi(/6/6!/4/2,/1:3,/1:9)",
+                text = null,
+                chapterIndex = null,
+                color = null,
+                style = null
+            )
+        )
+    }
+
+    @Test
+    fun `preview annotation target returns none when the cfi is missing`() {
+        assertEquals(
+            null,
+            previewAnnotationTarget(
+                annotationId = "annotation-1",
+                bookId = "book-1",
+                cfi = null,
+                text = null,
+                chapterIndex = null,
+                color = null,
+                style = null
+            )
+        )
+    }
+}

--- a/docs/bookorbit-api.md
+++ b/docs/bookorbit-api.md
@@ -172,6 +172,27 @@ POST /api/v1/books/query
 
 The Android client sends `q`, an empty `sort` list, and pagination capped at 100 results. Search results retain their returned `libraryId` so details and reading actions target the correct library.
 
+### Global annotations hub
+
+Endpoint:
+
+```text
+GET /api/v1/annotations
+```
+
+The endpoint is authenticated and scoped to the current user across accessible books and libraries. The current Android client consumes the paginated response for the global Annotations destination.
+
+Defaults and limits:
+
+- `status=active`
+- `page=1`
+- `pageSize=25`, maximum `100`
+- newest-first ordering by `createdAt`
+
+Supported hub filters include `bookId`, `search`, `chapter`, `colors`, `styles`, `origins`, `dateFrom`, `dateTo`, `hasNote`, `status`, `sortBy`, and `sortDir`. The response contains `items`, `total`, `page`, `pageSize`, and `stats`.
+
+`search` searches annotation text and note text only. It must not be treated as full-text search over the loaded EPUB, KEPUB, or PDF publication. Annotation items may include `cfi`, `jumpFileId`, `jumpFileFormat`, and `pageno`; the Android client preserves those fields for reader navigation. The Android client implements EPUB annotation creation, note/style updates, deletion, and durable offline mutation replay. Restore, conflict-safe hydration, PDF/comic creation, and publication full-text search remain pending.
+
 ### Series catalog filters
 
 Endpoint:


### PR DESCRIPTION
## Summary

This is the clean, partial issue #55 foundation required by the annotation reader work.

Included:
- annotation models and server parsing;
- global annotation browsing and selection entry point;
- durable create/update/delete mutation outbox with retry and local/server ID reconciliation;
- EPUB selection/locator plumbing needed by later reader navigation;
- focused queue, parser, and EPUB selection tests.

This PR intentionally does not close #55. PDF/comic annotation creation and broader publication search remain separate follow-up scope.

## Verification

- `:app:testDebugUnitTest` — 523 tests, 0 failures, 0 errors, 0 skipped in the clean composed snapshot
- `:app:compileDebugAndroidTestKotlin` — passed
- `:app:lintDebug` — passed
- `git -c core.whitespace=cr-at-eol diff --check` — passed

The clean branch was composed from current `origin/main` and excludes the historical stacked release/session/audiobook changes.
