### PR TITLE
feat: enhance audiobook player controls

### DIFF
--- a/app/src/androidTest/java/com/vangeaux/lagrange/AudiobookChapterListInsetsInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/vangeaux/lagrange/AudiobookChapterListInsetsInstrumentedTest.kt
@@ -1,0 +1,55 @@
+package com.vangeaux.lagrange
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class AudiobookChapterListInsetsInstrumentedTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun chapterListViewportStopsAboveNavigationControls() {
+        composeRule.setContent {
+            MaterialTheme {
+                FullPlayerChapterListSheet(
+                    chapters = List(20) { index ->
+                        AudiobookChapter(
+                            title = "Chapter ${index + 1}",
+                            startMs = index * 60_000L
+                        )
+                    },
+                    activeChapterIndex = 4,
+                    onChapterSelected = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        val sheetBounds = composeRule
+            .onNodeWithTag("audiobook-chapter-sheet")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val contentBounds = composeRule
+            .onNodeWithTag("audiobook-chapter-sheet-content")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val listBounds = composeRule
+            .onNodeWithTag("audiobook-chapter-list")
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+        assertTrue(
+            "The chapter list must end inside the sheet content",
+            listBounds.bottom <= contentBounds.bottom
+        )
+        assertTrue(
+            "The navigation-padded sheet content must keep the list above the sheet bottom",
+            listBounds.bottom < sheetBounds.bottom
+        )
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
@@ -171,6 +171,8 @@ class AppCoordinator(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val _screen = MutableStateFlow<AppScreen>(AppScreen.Loading)
     val screen: StateFlow<AppScreen> = _screen.asStateFlow()
+    private val _fullAudioPlayerBook = MutableStateFlow<BookSummary?>(null)
+    val fullAudioPlayerBook: StateFlow<BookSummary?> = _fullAudioPlayerBook.asStateFlow()
     private val _releaseUpdate = MutableStateFlow<ReleaseUpdate?>(null)
     val releaseUpdate: StateFlow<ReleaseUpdate?> = _releaseUpdate.asStateFlow()
     private val _releaseCheckStatus = MutableStateFlow(ReleaseCheckStatus.IDLE)
@@ -1551,6 +1553,14 @@ class AppCoordinator(
         } ?: loadBrowser()
     }
 
+    fun openAudioPlayer(book: BookSummary) {
+        _fullAudioPlayerBook.value = book
+    }
+
+    fun closeAudioPlayer() {
+        _fullAudioPlayerBook.value = null
+    }
+
     fun onAudioPlaybackProgress(
         book: BookSummary,
         position: Long,
@@ -1674,7 +1684,10 @@ class AppCoordinator(
             downloadMetadataByFileId = state.downloadMetadataByFileId + restored
         )
         lastBrowserState = next
-        if (_screen.value is AppScreen.ReaderLoading || _screen.value is AppScreen.Reader) {
+        if (
+            _screen.value is AppScreen.ReaderLoading ||
+            _screen.value is AppScreen.Reader
+        ) {
             return
         }
         _screen.value = AppScreen.Browser(browserState = next)

--- a/app/src/main/java/com/vangeaux/lagrange/AppPreferencesStore.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppPreferencesStore.kt
@@ -157,6 +157,26 @@ internal class AppPreferencesStore(context: Context) {
             .apply()
     }
 
+    fun readAudioSkipBackSeconds(): Int = normalizeAudioSkipSeconds(
+        preferences.getInt(AUDIO_SKIP_BACK_SECONDS_KEY, DEFAULT_AUDIO_SKIP_SECONDS)
+    )
+
+    fun saveAudioSkipBackSeconds(value: Int) {
+        preferences.edit()
+            .putInt(AUDIO_SKIP_BACK_SECONDS_KEY, normalizeAudioSkipSeconds(value))
+            .apply()
+    }
+
+    fun readAudioSkipForwardSeconds(): Int = normalizeAudioSkipSeconds(
+        preferences.getInt(AUDIO_SKIP_FORWARD_SECONDS_KEY, DEFAULT_AUDIO_SKIP_SECONDS)
+    )
+
+    fun saveAudioSkipForwardSeconds(value: Int) {
+        preferences.edit()
+            .putInt(AUDIO_SKIP_FORWARD_SECONDS_KEY, normalizeAudioSkipSeconds(value))
+            .apply()
+    }
+
     fun readIgnoredReleaseTag(): String? = preferences.getString(IGNORED_RELEASE_TAG_KEY, null)
 
     fun saveIgnoredReleaseTag(value: String) {
@@ -183,6 +203,9 @@ internal class AppPreferencesStore(context: Context) {
         const val LIBRARY_CARD_SIZE_KEY = "library_card_size"
         const val LIBRARY_READER_PREFERENCES_KEY = "library_reader_preferences"
         const val AUDIO_PLAYBACK_SPEED_KEY = "audio_playback_speed"
+        const val AUDIO_SKIP_BACK_SECONDS_KEY = "audio_skip_back_seconds"
+        const val AUDIO_SKIP_FORWARD_SECONDS_KEY = "audio_skip_forward_seconds"
+        const val DEFAULT_AUDIO_SKIP_SECONDS = 10
         const val IGNORED_RELEASE_TAG_KEY = "ignored_release_tag"
     }
 }
@@ -207,6 +230,11 @@ internal fun normalizeAudioPlaybackSpeed(value: Float): Float =
         ?: 1f
 
 internal val AUDIO_PLAYBACK_SPEED_OPTIONS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+
+internal val AUDIO_SKIP_SECONDS_OPTIONS = listOf(5, 10, 15, 30, 60)
+
+internal fun normalizeAudioSkipSeconds(value: Int): Int =
+    AUDIO_SKIP_SECONDS_OPTIONS.minByOrNull { option -> kotlin.math.abs(option - value) } ?: 10
 
 internal fun lockedOrientationStorageValue(value: LockedOrientation): String =
     value.name.lowercase()

--- a/app/src/main/java/com/vangeaux/lagrange/AudiobookFullPlayer.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AudiobookFullPlayer.kt
@@ -1,0 +1,1234 @@
+package com.vangeaux.lagrange
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.Forward30
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.media3.common.Player
+import android.content.res.Configuration
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class)
+private data class FullAudioSnapshot(
+    val isPlaying: Boolean,
+    val positionMs: Long,
+    val durationMs: Long,
+    val speed: Float
+)
+
+private fun fullAudioSnapshot(session: ReadiumAudioPlaybackService.Session): FullAudioSnapshot =
+    FullAudioSnapshot(
+        isPlaying = session.player.isPlaying,
+        positionMs = session.absolutePositionMs(),
+        durationMs = session.totalDurationMs(),
+        speed = session.player.playbackParameters.speed
+    )
+
+internal fun audiobookChapterBounds(
+    chapters: List<AudiobookChapter>,
+    positionMs: Long,
+    totalDurationMs: Long
+): Pair<Long, Long>? {
+    if (chapters.isEmpty() || totalDurationMs <= 0L) return null
+    val index = chapters.indexOfLast { it.startMs <= positionMs }.coerceAtLeast(0)
+    val startMs = chapters[index].startMs.coerceIn(0L, totalDurationMs)
+    val endMs = chapters.getOrNull(index + 1)?.startMs?.coerceIn(startMs, totalDurationMs)
+        ?: totalDurationMs
+    return startMs to endMs
+}
+
+internal fun audiobookChapterEndMs(
+    chapters: List<AudiobookChapter>,
+    positionMs: Long
+): Long? = chapters.getOrNull(chapters.indexOfLast { it.startMs <= positionMs } + 1)?.startMs
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun ReadiumFullAudioPlayer(
+    controller: ReadiumAudioPlaybackController,
+    onCollapse: () -> Unit,
+    onBookDetails: (BookSummary) -> Unit,
+    onClosePlayer: () -> Unit,
+    loadSessionHistory: suspend (BookSummary) -> List<AudiobookSessionEvent>,
+    clearSessionHistory: (BookSummary) -> Unit,
+    loadServerReadingSessions: suspend (String) -> BookReadingSessionsResult,
+    loadServerReadingAttempts: suspend (String) -> ReadingAttemptsResult
+) {
+    val playerLocked by controller.playerLocked.collectAsState()
+    val playerScope = rememberCoroutineScope()
+    val closePlayer = {
+        playerScope.launch {
+            controller.close()
+            onClosePlayer()
+        }
+    }
+    BackHandler(onBack = { if (!playerLocked) onCollapse() })
+    val session by produceState<ReadiumAudioPlaybackService.Session?>(null, controller) {
+        controller.session().collect { value = it }
+    }
+    val current = session
+    if (current == null) {
+        Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFF242222)) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Text("Preparing audiobook player…", color = Color.White)
+            }
+        }
+        return
+    }
+    val playback by produceState(fullAudioSnapshot(current), current.player) {
+        val listener = object : Player.Listener {
+            override fun onEvents(player: Player, events: Player.Events) {
+                value = fullAudioSnapshot(current)
+            }
+        }
+        current.player.addListener(listener)
+        try {
+            while (isActive) {
+                value = fullAudioSnapshot(current)
+                delay(500L)
+            }
+        } finally {
+            current.player.removeListener(listener)
+        }
+    }
+    val chapters = current.book.audioChapters
+    val bounds = audiobookChapterBounds(chapters, playback.positionMs, playback.durationMs)
+    val activeChapterIndex = chapters.indexOfLast { it.startMs <= playback.positionMs }.coerceAtLeast(0)
+    val chapterStartMs = bounds?.first ?: 0L
+    val chapterEndMs = bounds?.second ?: 1L
+    val chapterPositionMs = (playback.positionMs - chapterStartMs).coerceIn(0L, (chapterEndMs - chapterStartMs).coerceAtLeast(1L))
+    if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        FullPlayerLandscape(
+            controller = controller,
+            current = current,
+            playback = playback,
+            chapters = chapters,
+            activeChapterIndex = activeChapterIndex,
+            chapterStartMs = chapterStartMs,
+            chapterEndMs = chapterEndMs,
+            chapterPositionMs = chapterPositionMs,
+            chapterBoundsAvailable = bounds != null,
+            playerLocked = playerLocked,
+            onCollapse = onCollapse,
+            onBookDetails = onBookDetails,
+            onClosePlayer = onClosePlayer,
+            loadSessionHistory = loadSessionHistory,
+            clearSessionHistory = clearSessionHistory,
+            loadServerReadingSessions = loadServerReadingSessions,
+            loadServerReadingAttempts = loadServerReadingAttempts
+        )
+        return
+    }
+    val sleepTimer by controller.sleepTimer.collectAsState()
+    val context = LocalContext.current
+    val preferences = remember { AppPreferencesStore(context) }
+    var skipBackSeconds by remember { mutableIntStateOf(preferences.readAudioSkipBackSeconds()) }
+    var skipForwardSeconds by remember { mutableIntStateOf(preferences.readAudioSkipForwardSeconds()) }
+    var intervalDirection by remember { mutableStateOf<SkipDirection?>(null) }
+    var sleepMenuExpanded by remember { mutableStateOf(false) }
+    var chapterMenuExpanded by remember { mutableStateOf(false) }
+    var speedMenuExpanded by remember { mutableStateOf(false) }
+    var overflowExpanded by remember { mutableStateOf(false) }
+    var showSessionHistory by remember { mutableStateOf(false) }
+    var sessionHistory by remember(current.book.id, current.book.fileId) { mutableStateOf(emptyList<AudiobookSessionEvent>()) }
+    var serverReadingSessions by remember(current.book.id, current.book.fileId) { mutableStateOf<BookReadingSessionsResult?>(null) }
+    var serverReadingAttempts by remember(current.book.id, current.book.fileId) { mutableStateOf<ReadingAttemptsResult?>(null) }
+    var loadingServerReadingHistory by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
+    var showChapterList by remember { mutableStateOf(false) }
+    var showCoverViewer by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
+    var overallSeekPosition by remember { mutableFloatStateOf(playback.positionMs.toFloat()) }
+    var chapterSeekPosition by remember { mutableFloatStateOf(chapterPositionMs.toFloat()) }
+    var isSeekingOverall by remember { mutableStateOf(false) }
+    var isSeekingChapter by remember { mutableStateOf(false) }
+    LaunchedEffect(playback.positionMs, isSeekingOverall, isSeekingChapter) {
+        if (!isSeekingOverall) overallSeekPosition = playback.positionMs.toFloat()
+        if (!isSeekingChapter) chapterSeekPosition = chapterPositionMs.toFloat()
+    }
+    LaunchedEffect(showSessionHistory, current.book.id, current.book.fileId) {
+        if (showSessionHistory) {
+            sessionHistory = loadSessionHistory(current.book)
+            loadingServerReadingHistory = true
+            serverReadingSessions = loadServerReadingSessions(current.book.id)
+            serverReadingAttempts = loadServerReadingAttempts(current.book.id)
+            loadingServerReadingHistory = false
+        }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFF242222), contentColor = Color.White) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val groupScale = fullPlayerGroupScale(maxHeight.value, landscape = false)
+            val contentPadding = (24f * groupScale).coerceAtLeast(16f).dp
+            val verticalPadding = (8f * groupScale).coerceAtLeast(4f).dp
+            val sectionGap = (8f * groupScale).coerceAtLeast(4f).dp
+            val controlGap = (12f * groupScale).coerceAtLeast(6f).dp
+            val coverFraction = (0.5f * groupScale).coerceAtLeast(0.36f)
+            val primaryControlSize = (76f * groupScale).coerceAtLeast(64f).dp
+            val secondaryControlSize = (76f * groupScale).coerceAtLeast(64f).dp
+            val titleStyle = MaterialTheme.typography.titleLarge.copy(
+                fontSize = MaterialTheme.typography.titleLarge.fontSize * groupScale
+            )
+            Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = contentPadding, vertical = verticalPadding),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                IconButton(onClick = onCollapse, enabled = !playerLocked) {
+                    Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Collapse audiobook player")
+                }
+                Text(
+                    text = if (current.book.isDownloaded) "LOCAL FILE" else "STREAM",
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.titleMedium,
+                    letterSpacing = MaterialTheme.typography.titleMedium.letterSpacing
+                )
+                Box {
+                    IconButton(onClick = { overflowExpanded = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More audiobook actions")
+                    }
+                    DropdownMenu(
+                        expanded = overflowExpanded,
+                        onDismissRequest = { overflowExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Play session history") },
+                            onClick = {
+                                overflowExpanded = false
+                                showSessionHistory = true
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text(if (playerLocked) "Unlock player" else "Lock player") },
+                            onClick = {
+                                overflowExpanded = false
+                                controller.setPlayerLocked(!playerLocked)
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Close player") },
+                            onClick = {
+                                overflowExpanded = false
+                                closePlayer()
+                            }
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                val coverHeight = minOf(
+                    maxHeight * coverFraction,
+                    maxWidth / current.book.coverAspectRatio.widthToHeight
+                )
+                CompactAudiobookCover(
+                    book = current.book,
+                    coverLoader = controller::loadCover,
+                    modifier = Modifier
+                        .width(coverHeight * current.book.coverAspectRatio.widthToHeight)
+                        .height(coverHeight),
+                    coverHeight = null,
+                    onClick = { showCoverViewer = true }
+                )
+            }
+            Spacer(Modifier.height(sectionGap))
+            Text(
+                text = current.book.title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .clickable { onBookDetails(current.book) },
+                style = titleStyle,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = current.book.seriesName
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { series ->
+                        val index = current.book.seriesIndex?.let(::formatFullPlayerSeriesIndex)
+                        if (index == null) series else "$series · #$index"
+                    }
+                    .orEmpty(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(enabled = !current.book.seriesName.isNullOrBlank()) {
+                        onBookDetails(current.book)
+                    },
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize * groupScale
+                ),
+                color = Color.White.copy(alpha = 0.65f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = chapters.getOrNull(activeChapterIndex)?.title ?: "Audiobook",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .basicMarquee(iterations = Int.MAX_VALUE),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontSize = MaterialTheme.typography.titleMedium.fontSize * groupScale
+                ),
+                color = Color.White.copy(alpha = 0.82f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+            Spacer(Modifier.height(sectionGap))
+            AudioSeekBar(
+                positionMs = overallSeekPosition,
+                durationMs = playback.durationMs,
+                onSeeking = { isSeekingOverall = true; overallSeekPosition = it },
+                onSeekFinished = { current.seekToAbsolutePosition(overallSeekPosition.toLong()); isSeekingOverall = false },
+                leading = formatPlaybackTime(overallSeekPosition.toLong()),
+                trailing = "−${formatPlaybackTime((playback.durationMs - overallSeekPosition).toLong().coerceAtLeast(0L))}",
+                label = "Book progress",
+                layoutScale = groupScale,
+                description = "Seek through audiobook"
+            )
+            AudioSeekBar(
+                positionMs = chapterSeekPosition,
+                durationMs = (chapterEndMs - chapterStartMs).coerceAtLeast(1L),
+                onSeeking = { isSeekingChapter = true; chapterSeekPosition = it },
+                onSeekFinished = {
+                    current.seekToAbsolutePosition(chapterStartMs + chapterSeekPosition.toLong())
+                    isSeekingChapter = false
+                },
+                leading = formatPlaybackTime(chapterSeekPosition.toLong()),
+                trailing = "−${formatPlaybackTime((chapterEndMs - chapterStartMs - chapterSeekPosition).toLong().coerceAtLeast(0L))}",
+                label = "Chapter progress",
+                layoutScale = groupScale,
+                description = "Seek through current chapter",
+                enabled = bounds != null
+            )
+            Spacer(Modifier.height(controlGap))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (!playerLocked) FullPlayerIconButton(
+                    icon = Icons.Default.SkipPrevious,
+                    description = "Previous audiobook chapter",
+                    onClick = {
+                        val previous = chapters.getOrNull(activeChapterIndex - 1)?.startMs
+                        if (previous != null) current.seekToAbsolutePosition(previous) else current.seekToAbsolutePosition(chapterStartMs)
+                    }
+                )
+                if (!playerLocked) FullPlayerIconButton(
+                    icon = Icons.Default.Replay10,
+                    description = "Skip back $skipBackSeconds seconds",
+                    onClick = {
+                        current.seekToAbsolutePosition((current.absolutePositionMs() - skipBackSeconds * 1000L).coerceAtLeast(0L))
+                    },
+                    onLongClick = { intervalDirection = SkipDirection.BACK }
+                )
+                IconButton(
+                    onClick = { if (playback.isPlaying) current.player.pause() else current.player.play() },
+                    modifier = Modifier.size(primaryControlSize).background(MaterialTheme.colorScheme.primary, CircleShape)
+                ) {
+                    Icon(
+                        if (playback.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (playback.isPlaying) "Pause audiobook" else "Play audiobook",
+                        modifier = Modifier.size((38f * groupScale).coerceAtLeast(32f).dp)
+                    )
+                }
+                if (!playerLocked) FullPlayerIconButton(
+                    icon = Icons.Default.Forward30,
+                    description = "Skip forward $skipForwardSeconds seconds",
+                    onClick = {
+                        current.seekToAbsolutePosition(
+                            (current.absolutePositionMs() + skipForwardSeconds * 1000L)
+                                .coerceAtMost(playback.durationMs)
+                        )
+                    },
+                    onLongClick = { intervalDirection = SkipDirection.FORWARD }
+                )
+                if (!playerLocked) FullPlayerIconButton(
+                    icon = Icons.Default.SkipNext,
+                    description = "Next audiobook chapter",
+                    onClick = {
+                        chapters.getOrNull(activeChapterIndex + 1)?.startMs?.let(current::seekToAbsolutePosition)
+                    }
+                )
+            }
+            Spacer(Modifier.height(controlGap))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                Box {
+                    IconButton(
+                        onClick = { showChapterList = true },
+                        enabled = chapters.isNotEmpty(),
+                        modifier = Modifier.size(secondaryControlSize)
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(Icons.AutoMirrored.Filled.List, contentDescription = null)
+                            Text("Chapter", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    DropdownMenu(expanded = chapterMenuExpanded, onDismissRequest = { chapterMenuExpanded = false }) {
+                        chapters.forEachIndexed { index, chapter ->
+                            AudiobookChapterMenuItem(
+                                index = index,
+                                title = chapter.title,
+                                selected = index == activeChapterIndex,
+                                onClick = { chapterMenuExpanded = false; current.seekToAbsolutePosition(chapter.startMs) }
+                            )
+                        }
+                    }
+                }
+                Box {
+                    TextButton(
+                        onClick = { speedMenuExpanded = true },
+                        modifier = Modifier.width((104f * groupScale).coerceAtLeast(88f).dp).height(secondaryControlSize),
+                        contentPadding = PaddingValues(horizontal = 8.dp)
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Text(
+                                "${formatPlaybackSpeed(playback.speed.toDouble())}×",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Text("Speed", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    DropdownMenu(expanded = speedMenuExpanded, onDismissRequest = { speedMenuExpanded = false }) {
+                        AUDIO_PLAYBACK_SPEED_OPTIONS.forEach { speed ->
+                            DropdownMenuItem(
+                                text = { Text("${formatPlaybackSpeed(speed.toDouble())}×") },
+                                onClick = { speedMenuExpanded = false; controller.setPlaybackSpeed(current.player, speed) }
+                            )
+                        }
+                    }
+                }
+                Box {
+                    IconButton(
+                        onClick = { sleepMenuExpanded = true },
+                        modifier = Modifier.size(secondaryControlSize)
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(Icons.Default.Bedtime, contentDescription = null)
+                            Text("Sleep", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    DropdownMenu(expanded = sleepMenuExpanded, onDismissRequest = { sleepMenuExpanded = false }) {
+                        AudioSleepTimerOption.entries.forEach { option ->
+                            DropdownMenuItem(
+                                text = {
+                                    val remaining = sleepTimer.remainingMs
+                                    Text(
+                                        if (option == sleepTimer.option && remaining != null) {
+                                            "${option.label} · ${formatPlaybackTime(remaining)}"
+                                        } else {
+                                            option.label
+                                        }
+                                    )
+                                },
+                                onClick = { sleepMenuExpanded = false; controller.setSleepTimer(option) }
+                            )
+                        }
+                    }
+                }
+            }
+            if (sleepTimer.option != AudioSleepTimerOption.OFF) {
+                Text(
+                    text = "Sleep timer: ${sleepTimer.option.label} · ${sleepTimer.remainingMs?.let(::formatPlaybackTime).orEmpty()}",
+                    color = Color.White.copy(alpha = 0.65f),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+        }
+    }
+
+    if (showSessionHistory) {
+        FullPlayerSessionHistoryDialog(
+            bookTitle = current.book.title,
+            events = sessionHistory,
+            isLoadingServerReadingHistory = loadingServerReadingHistory,
+            serverReadingSessions = serverReadingSessions,
+            serverReadingAttempts = serverReadingAttempts,
+            onEventClick = { event ->
+                current.seekToAbsolutePosition(event.positionMs)
+                showSessionHistory = false
+            },
+            onClearClick = {
+                sessionHistory = emptyList<AudiobookSessionEvent>()
+                clearSessionHistory(current.book)
+            },
+            onCloseClick = { showSessionHistory = false }
+        )
+    }
+    if (showChapterList) {
+        FullPlayerChapterListSheet(
+            chapters = chapters,
+            activeChapterIndex = activeChapterIndex,
+            onChapterSelected = { chapter ->
+                current.seekToAbsolutePosition(chapter.startMs)
+                showChapterList = false
+            },
+            onClose = { showChapterList = false }
+        )
+    }
+    if (showCoverViewer) {
+        FullScreenCoverViewer(
+            book = current.book,
+            coverLoader = controller::loadCover,
+            onDismiss = { showCoverViewer = false }
+        )
+    }
+
+    intervalDirection?.let { direction ->
+        AlertDialog(
+            onDismissRequest = { intervalDirection = null },
+            title = { Text(if (direction == SkipDirection.BACK) "Rewind interval" else "Forward interval") },
+            text = {
+                Column {
+                    AUDIO_SKIP_SECONDS_OPTIONS.forEach { seconds ->
+                        TextButton(
+                            onClick = {
+                                if (direction == SkipDirection.BACK) {
+                                    skipBackSeconds = seconds
+                                    preferences.saveAudioSkipBackSeconds(seconds)
+                                } else {
+                                    skipForwardSeconds = seconds
+                                    preferences.saveAudioSkipForwardSeconds(seconds)
+                                }
+                                intervalDirection = null
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text("$seconds seconds") }
+                    }
+                }
+            },
+            confirmButton = { TextButton(onClick = { intervalDirection = null }) { Text("Cancel") } }
+        )
+    }
+}
+
+@Composable
+private fun FullPlayerSessionHistoryDialog(
+    bookTitle: String,
+    events: List<AudiobookSessionEvent>,
+    isLoadingServerReadingHistory: Boolean,
+    serverReadingSessions: BookReadingSessionsResult?,
+    serverReadingAttempts: ReadingAttemptsResult?,
+    onEventClick: (AudiobookSessionEvent) -> Unit,
+    onClearClick: () -> Unit,
+    onCloseClick: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onCloseClick,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color(0xFF242222),
+            contentColor = Color.White
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .statusBarsPadding()
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onCloseClick) {
+                        Icon(Icons.Default.Close, contentDescription = "Close session history")
+                    }
+                    Text(
+                        text = "Session history",
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = Color.White
+                    )
+                }
+                AudiobookSessionHistory(
+                    bookTitle = bookTitle,
+                    events = events,
+                    isLoadingServerReadingHistory = isLoadingServerReadingHistory,
+                    serverReadingSessions = serverReadingSessions,
+                    serverReadingAttempts = serverReadingAttempts,
+                    onEventClick = onEventClick,
+                    onClearClick = onClearClick,
+                    onCloseClick = onCloseClick
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FullPlayerChapterListSheet(
+    chapters: List<AudiobookChapter>,
+    activeChapterIndex: Int,
+    onChapterSelected: (AudiobookChapter) -> Unit,
+    onClose: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onClose,
+        sheetState = sheetState,
+        modifier = Modifier
+            .fillMaxHeight()
+            .testTag("audiobook-chapter-sheet"),
+        shape = RectangleShape,
+        containerColor = Color(0xFF242222),
+        contentColor = Color.White,
+        dragHandle = null
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("audiobook-chapter-sheet-content")
+                .navigationBarsPadding()
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onClose) {
+                    Icon(Icons.Default.Close, contentDescription = "Close chapter list")
+                }
+                Text(
+                    text = "Chapters",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Color.White
+                )
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("audiobook-chapter-list"),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                itemsIndexed(chapters) { index, chapter ->
+                    AudiobookChapterMenuItem(
+                        index = index,
+                        title = chapter.title,
+                        selected = index == activeChapterIndex,
+                        onClick = { onChapterSelected(chapter) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AudiobookChapterMenuItem(
+    index: Int,
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+        color = if (selected) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            Color.Transparent
+        },
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+            Text(
+                "Chapter ${index + 1}",
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.labelMedium
+            )
+            Text(
+                title.ifBlank { "Chapter ${index + 1}" },
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun FullPlayerLandscape(
+    controller: ReadiumAudioPlaybackController,
+    current: ReadiumAudioPlaybackService.Session,
+    playback: FullAudioSnapshot,
+    chapters: List<AudiobookChapter>,
+    activeChapterIndex: Int,
+    chapterStartMs: Long,
+    chapterEndMs: Long,
+    chapterPositionMs: Long,
+    chapterBoundsAvailable: Boolean,
+    playerLocked: Boolean,
+    onCollapse: () -> Unit,
+    onBookDetails: (BookSummary) -> Unit,
+    onClosePlayer: () -> Unit,
+    loadSessionHistory: suspend (BookSummary) -> List<AudiobookSessionEvent>,
+    clearSessionHistory: (BookSummary) -> Unit,
+    loadServerReadingSessions: suspend (String) -> BookReadingSessionsResult,
+    loadServerReadingAttempts: suspend (String) -> ReadingAttemptsResult
+) {
+    val playerScope = rememberCoroutineScope()
+    val closePlayer = {
+        playerScope.launch {
+            controller.close()
+            onClosePlayer()
+        }
+    }
+    BackHandler(onBack = { if (!playerLocked) onCollapse() })
+    val context = LocalContext.current
+    val preferences = remember { AppPreferencesStore(context) }
+    val sleepTimer by controller.sleepTimer.collectAsState()
+    var showCoverViewer by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
+    var chapterMenuExpanded by remember { mutableStateOf(false) }
+    var speedMenuExpanded by remember { mutableStateOf(false) }
+    var sleepMenuExpanded by remember { mutableStateOf(false) }
+    var overflowExpanded by remember { mutableStateOf(false) }
+    var showSessionHistory by remember { mutableStateOf(false) }
+    var sessionHistory by remember(current.book.id, current.book.fileId) { mutableStateOf(emptyList<AudiobookSessionEvent>()) }
+    var serverReadingSessions by remember(current.book.id, current.book.fileId) { mutableStateOf<BookReadingSessionsResult?>(null) }
+    var serverReadingAttempts by remember(current.book.id, current.book.fileId) { mutableStateOf<ReadingAttemptsResult?>(null) }
+    var loadingServerReadingHistory by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
+    var showChapterList by remember { mutableStateOf(false) }
+    var intervalDirection by remember { mutableStateOf<SkipDirection?>(null) }
+    var skipBackSeconds by remember { mutableIntStateOf(preferences.readAudioSkipBackSeconds()) }
+    var skipForwardSeconds by remember { mutableIntStateOf(preferences.readAudioSkipForwardSeconds()) }
+    var overallPosition by remember { mutableFloatStateOf(playback.positionMs.toFloat()) }
+    var chapterPosition by remember { mutableFloatStateOf(chapterPositionMs.toFloat()) }
+    var isSeekingOverall by remember { mutableStateOf(false) }
+    var isSeekingChapter by remember { mutableStateOf(false) }
+    LaunchedEffect(playback.positionMs, isSeekingOverall, isSeekingChapter) {
+        if (!isSeekingOverall) overallPosition = playback.positionMs.toFloat()
+        if (!isSeekingChapter) chapterPosition = chapterPositionMs.toFloat()
+    }
+    LaunchedEffect(showSessionHistory, current.book.id, current.book.fileId) {
+        if (showSessionHistory) {
+            sessionHistory = loadSessionHistory(current.book)
+            loadingServerReadingHistory = true
+            serverReadingSessions = loadServerReadingSessions(current.book.id)
+            serverReadingAttempts = loadServerReadingAttempts(current.book.id)
+            loadingServerReadingHistory = false
+        }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = Color(0xFF242222),
+        contentColor = Color.White
+    ) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val groupScale = fullPlayerGroupScale(maxHeight.value, landscape = true)
+            val contentPadding = (16f * groupScale).coerceAtLeast(8f).dp
+            val controlGap = (8f * groupScale).coerceAtLeast(2f).dp
+            val secondaryControlSize = 64.dp
+            val primaryControlSize = (72f * groupScale).coerceAtLeast(64f).dp
+            val titleStyle = MaterialTheme.typography.titleLarge.copy(
+                fontSize = MaterialTheme.typography.titleLarge.fontSize * groupScale
+            )
+            Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = contentPadding, vertical = (8f * groupScale).coerceAtLeast(2f).dp),
+            horizontalArrangement = Arrangement.spacedBy((20f * groupScale).coerceAtLeast(10f).dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BoxWithConstraints(
+                modifier = Modifier
+                    .weight(0.42f)
+                    .fillMaxHeight(),
+                contentAlignment = Alignment.Center
+            ) {
+                val coverHeight = minOf(
+                    maxHeight,
+                    maxWidth / current.book.coverAspectRatio.widthToHeight
+                )
+                CompactAudiobookCover(
+                    book = current.book,
+                    coverLoader = controller::loadCover,
+                    modifier = Modifier
+                        .width(coverHeight * current.book.coverAspectRatio.widthToHeight)
+                        .height(coverHeight),
+                    coverHeight = null,
+                    onClick = { showCoverViewer = true }
+                )
+            }
+            Column(
+                modifier = Modifier.weight(0.58f).fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(controlGap)
+            ) {
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = onCollapse, enabled = !playerLocked) {
+                        Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Collapse audiobook player")
+                    }
+                    Text(
+                        text = if (current.book.isDownloaded) "LOCAL FILE" else "STREAM",
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Box {
+                        IconButton(onClick = { overflowExpanded = true }) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "More audiobook actions")
+                        }
+                        DropdownMenu(expanded = overflowExpanded, onDismissRequest = { overflowExpanded = false }) {
+                            DropdownMenuItem(
+                                text = { Text("Play session history") },
+                                onClick = {
+                                    overflowExpanded = false
+                                    showSessionHistory = true
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text(if (playerLocked) "Unlock player" else "Lock player") },
+                                onClick = {
+                                    overflowExpanded = false
+                                    controller.setPlayerLocked(!playerLocked)
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Close player") },
+                                onClick = {
+                                    overflowExpanded = false
+                                    closePlayer()
+                                }
+                            )
+                        }
+                    }
+                }
+                Text(
+                    text = current.book.title,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .clickable { onBookDetails(current.book) },
+                    style = titleStyle,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = current.book.seriesName
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { series ->
+                            val index = current.book.seriesIndex?.let(::formatFullPlayerSeriesIndex)
+                            if (index == null) series else "$series · #$index"
+                        }
+                        .orEmpty(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(enabled = !current.book.seriesName.isNullOrBlank()) {
+                            onBookDetails(current.book)
+                        },
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontSize = MaterialTheme.typography.bodyLarge.fontSize * groupScale
+                    ),
+                    color = Color.White.copy(alpha = 0.65f),
+                    maxLines = 1,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = chapters.getOrNull(activeChapterIndex)?.title ?: "Audiobook",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .basicMarquee(iterations = Int.MAX_VALUE),
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = MaterialTheme.typography.titleMedium.fontSize * groupScale
+                    ),
+                    color = Color.White.copy(alpha = 0.82f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(Modifier.height((8f * groupScale).coerceAtLeast(2f).dp))
+                AudioSeekBar(
+                    positionMs = overallPosition,
+                    durationMs = playback.durationMs,
+                    onSeeking = { isSeekingOverall = true; overallPosition = it },
+                    onSeekFinished = { current.seekToAbsolutePosition(overallPosition.toLong()); isSeekingOverall = false },
+                    leading = formatPlaybackTime(overallPosition.toLong()),
+                    trailing = "−${formatPlaybackTime((playback.durationMs - overallPosition).toLong().coerceAtLeast(0L))}",
+                    label = "Book progress",
+                    layoutScale = groupScale,
+                    description = "Seek through audiobook"
+                )
+                AudioSeekBar(
+                    positionMs = chapterPosition,
+                    durationMs = (chapterEndMs - chapterStartMs).coerceAtLeast(1L),
+                    onSeeking = { isSeekingChapter = true; chapterPosition = it },
+                    onSeekFinished = {
+                        current.seekToAbsolutePosition(chapterStartMs + chapterPosition.toLong())
+                        isSeekingChapter = false
+                    },
+                    leading = formatPlaybackTime(chapterPosition.toLong()),
+                    trailing = "−${formatPlaybackTime((chapterEndMs - chapterStartMs - chapterPosition).toLong().coerceAtLeast(0L))}",
+                    label = "Chapter progress",
+                    layoutScale = groupScale,
+                    description = "Seek through current chapter",
+                    enabled = chapterBoundsAvailable
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (!playerLocked) FullPlayerIconButton(
+                        icon = Icons.Default.SkipPrevious,
+                        description = "Previous audiobook chapter",
+                        onClick = {
+                            chapters.getOrNull(activeChapterIndex - 1)?.startMs?.let(current::seekToAbsolutePosition)
+                        }
+                    )
+                    if (!playerLocked) FullPlayerIconButton(
+                        icon = Icons.Default.Replay10,
+                        description = "Skip back $skipBackSeconds seconds",
+                        onClick = {
+                            current.seekToAbsolutePosition((current.absolutePositionMs() - skipBackSeconds * 1000L).coerceAtLeast(0L))
+                        },
+                        onLongClick = { intervalDirection = SkipDirection.BACK }
+                    )
+                    IconButton(
+                        onClick = { if (playback.isPlaying) current.player.pause() else current.player.play() },
+                        modifier = Modifier.size(primaryControlSize).background(MaterialTheme.colorScheme.primary, CircleShape)
+                    ) {
+                        Icon(
+                            if (playback.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            contentDescription = if (playback.isPlaying) "Pause audiobook" else "Play audiobook",
+                            modifier = Modifier.size((36f * groupScale).coerceAtLeast(30f).dp)
+                        )
+                    }
+                    if (!playerLocked) FullPlayerIconButton(
+                        icon = Icons.Default.Forward30,
+                        description = "Skip forward $skipForwardSeconds seconds",
+                        onClick = {
+                            current.seekToAbsolutePosition((current.absolutePositionMs() + skipForwardSeconds * 1000L).coerceAtMost(playback.durationMs))
+                        },
+                        onLongClick = { intervalDirection = SkipDirection.FORWARD }
+                    )
+                    if (!playerLocked) FullPlayerIconButton(
+                        icon = Icons.Default.SkipNext,
+                        description = "Next audiobook chapter",
+                        onClick = { chapters.getOrNull(activeChapterIndex + 1)?.startMs?.let(current::seekToAbsolutePosition) }
+                    )
+                }
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                    Box {
+                        IconButton(onClick = { showChapterList = true }, enabled = chapters.isNotEmpty(), modifier = Modifier.size(secondaryControlSize)) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(Icons.AutoMirrored.Filled.List, contentDescription = null)
+                                Text("Chapter", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                        DropdownMenu(expanded = chapterMenuExpanded, onDismissRequest = { chapterMenuExpanded = false }) {
+                            chapters.forEachIndexed { index, chapter ->
+                                AudiobookChapterMenuItem(
+                                    index = index,
+                                    title = chapter.title,
+                                    selected = index == activeChapterIndex,
+                                    onClick = { chapterMenuExpanded = false; current.seekToAbsolutePosition(chapter.startMs) }
+                                )
+                            }
+                        }
+                    }
+                    Box {
+                        TextButton(onClick = { speedMenuExpanded = true }, modifier = Modifier.width((96f * groupScale).coerceAtLeast(88f).dp).height(secondaryControlSize), contentPadding = PaddingValues(horizontal = 4.dp)) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    "${formatPlaybackSpeed(playback.speed.toDouble())}×",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                                Text("Speed", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                        DropdownMenu(expanded = speedMenuExpanded, onDismissRequest = { speedMenuExpanded = false }) {
+                            AUDIO_PLAYBACK_SPEED_OPTIONS.forEach { speed ->
+                                DropdownMenuItem(
+                                    text = { Text("${formatPlaybackSpeed(speed.toDouble())}×") },
+                                    onClick = { speedMenuExpanded = false; controller.setPlaybackSpeed(current.player, speed) }
+                                )
+                            }
+                        }
+                    }
+                    Box {
+                        IconButton(onClick = { sleepMenuExpanded = true }, modifier = Modifier.size(secondaryControlSize)) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(Icons.Default.Bedtime, contentDescription = null)
+                                Text("Sleep", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                        DropdownMenu(expanded = sleepMenuExpanded, onDismissRequest = { sleepMenuExpanded = false }) {
+                            AudioSleepTimerOption.entries.forEach { option ->
+                                DropdownMenuItem(
+                                    text = { Text(option.label) },
+                                    onClick = { sleepMenuExpanded = false; controller.setSleepTimer(option) }
+                                )
+                            }
+                        }
+                    }
+                }
+                if (sleepTimer.option != AudioSleepTimerOption.OFF) {
+                    Text(
+                        text = "Sleep timer: ${sleepTimer.option.label} · ${sleepTimer.remainingMs?.let(::formatPlaybackTime).orEmpty()}",
+                        color = Color.White.copy(alpha = 0.65f),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+        }
+        }
+    }
+    if (showSessionHistory) {
+        FullPlayerSessionHistoryDialog(
+            bookTitle = current.book.title,
+            events = sessionHistory,
+            isLoadingServerReadingHistory = loadingServerReadingHistory,
+            serverReadingSessions = serverReadingSessions,
+            serverReadingAttempts = serverReadingAttempts,
+            onEventClick = { event ->
+                current.seekToAbsolutePosition(event.positionMs)
+                showSessionHistory = false
+            },
+            onClearClick = {
+                sessionHistory = emptyList<AudiobookSessionEvent>()
+                clearSessionHistory(current.book)
+            },
+            onCloseClick = { showSessionHistory = false }
+        )
+    }
+    if (showChapterList) {
+        FullPlayerChapterListSheet(
+            chapters = chapters,
+            activeChapterIndex = activeChapterIndex,
+            onChapterSelected = { chapter ->
+                current.seekToAbsolutePosition(chapter.startMs)
+                showChapterList = false
+            },
+            onClose = { showChapterList = false }
+        )
+    }
+    if (showCoverViewer) {
+        FullScreenCoverViewer(book = current.book, coverLoader = controller::loadCover) {
+            showCoverViewer = false
+        }
+    }
+    intervalDirection?.let { direction ->
+        AlertDialog(
+            onDismissRequest = { intervalDirection = null },
+            title = { Text(if (direction == SkipDirection.BACK) "Rewind interval" else "Forward interval") },
+            text = {
+                Column {
+                    AUDIO_SKIP_SECONDS_OPTIONS.forEach { seconds ->
+                        TextButton(
+                            onClick = {
+                                if (direction == SkipDirection.BACK) {
+                                    skipBackSeconds = seconds
+                                    preferences.saveAudioSkipBackSeconds(seconds)
+                                } else {
+                                    skipForwardSeconds = seconds
+                                    preferences.saveAudioSkipForwardSeconds(seconds)
+                                }
+                                intervalDirection = null
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        ) { Text("$seconds seconds") }
+                    }
+                }
+            },
+            confirmButton = { TextButton(onClick = { intervalDirection = null }) { Text("Cancel") } }
+        )
+    }
+}
+
+private enum class SkipDirection { BACK, FORWARD }
+
+internal fun fullPlayerGroupScale(availableHeightDp: Float, landscape: Boolean): Float {
+    if (!availableHeightDp.isFinite() || availableHeightDp <= 0f) return 1f
+    val designHeightDp = if (landscape) 520f else 780f
+    val minimumScale = if (landscape) 0.68f else 0.76f
+    return (availableHeightDp / designHeightDp).coerceIn(minimumScale, 1f)
+}
+
+internal fun formatFullPlayerSeriesIndex(value: Double): String =
+    if (value % 1.0 == 0.0) value.toInt().toString() else value.toString()
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun FullPlayerIconButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null
+) {
+    Box(
+        modifier = Modifier
+            .size(52.dp)
+            .then(
+                if (onLongClick != null) {
+                    Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                } else {
+                    Modifier.clickable(onClick = onClick)
+                }
+            )
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(icon, contentDescription = null, modifier = Modifier.size(30.dp))
+    }
+}
+
+@Composable
+private fun AudioSeekBar(
+    positionMs: Float,
+    durationMs: Long,
+    onSeeking: (Float) -> Unit,
+    onSeekFinished: () -> Unit,
+    leading: String,
+    trailing: String,
+    label: String,
+    layoutScale: Float,
+    description: String,
+    enabled: Boolean = true
+) {
+    Column(modifier = Modifier.fillMaxWidth().semantics { contentDescription = description }) {
+        val timestampStyle = MaterialTheme.typography.labelMedium.copy(
+            fontSize = (MaterialTheme.typography.labelMedium.fontSize.value * layoutScale).coerceAtLeast(10f).sp
+        )
+        val progressLabelStyle = MaterialTheme.typography.labelSmall.copy(
+            fontSize = (MaterialTheme.typography.labelSmall.fontSize.value * layoutScale).coerceAtLeast(9f).sp
+        )
+        Box(modifier = Modifier.fillMaxWidth().height((20f * layoutScale).coerceAtLeast(16f).dp)) {
+            Text(
+                leading,
+                modifier = Modifier.align(Alignment.CenterStart),
+                style = timestampStyle
+            )
+            Text(
+                label,
+                modifier = Modifier.align(Alignment.Center),
+                style = progressLabelStyle,
+                color = Color.White.copy(alpha = 0.65f)
+            )
+            Text(
+                trailing,
+                modifier = Modifier.align(Alignment.CenterEnd),
+                style = timestampStyle
+            )
+        }
+        Slider(
+            value = positionMs.coerceIn(0f, durationMs.toFloat()),
+            onValueChange = onSeeking,
+            onValueChangeFinished = onSeekFinished,
+            valueRange = 0f..durationMs.toFloat().coerceAtLeast(1f),
+            enabled = enabled,
+            colors = SliderDefaults.colors(
+                activeTrackColor = MaterialTheme.colorScheme.primary,
+                inactiveTrackColor = Color.White.copy(alpha = 0.42f),
+                thumbColor = MaterialTheme.colorScheme.primary
+            ),
+            modifier = Modifier.fillMaxWidth().height((32f * layoutScale).coerceAtLeast(24f).dp)
+        )
+    }
+}

--- a/app/src/main/java/com/vangeaux/lagrange/AudiobookPlayerUi.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AudiobookPlayerUi.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -79,6 +80,7 @@ private fun audioPlayerSnapshot(session: ReadiumAudioPlaybackService.Session): A
         speed = session.player.playbackParameters.speed
     )
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 internal fun ReadiumCompactAudioPlayer(
     controller: ReadiumAudioPlaybackController,
@@ -180,7 +182,7 @@ internal fun ReadiumCompactAudioPlayer(
     val positionMs = playback.positionMs
     val durationMs = playback.durationMs
     val scope = rememberCoroutineScope()
-    var chapterMenuExpanded by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
+    var showChapterList by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
     var speedMenuExpanded by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
     var isSeeking by remember(current.book.id, current.book.fileId) { mutableStateOf(false) }
     var seekPositionMs by remember(current.book.id, current.book.fileId) {
@@ -223,23 +225,38 @@ internal fun ReadiumCompactAudioPlayer(
                 modifier = Modifier
                     .weight(1f)
                     .padding(start = 8.dp)
+                    .clickable { onCoverClick(current.book) }
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
                             current.book.title,
+                            modifier = Modifier.basicMarquee(iterations = Int.MAX_VALUE),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.titleSmall,
                             fontWeight = FontWeight.SemiBold
                         )
-                        Text(
-                            current.book.author.orEmpty(),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.bodySmall
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                current.book.seriesName.orEmpty(),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .basicMarquee(iterations = Int.MAX_VALUE),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            current.book.seriesIndex?.let { index ->
+                                Text(
+                                    "#${formatFullPlayerSeriesIndex(index)}",
+                                    modifier = Modifier.padding(start = 6.dp),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
                     }
                     IconButton(
                         onClick = {
@@ -291,7 +308,7 @@ internal fun ReadiumCompactAudioPlayer(
                 ) {
                     Box {
                         IconButton(
-                            onClick = { chapterMenuExpanded = true },
+                            onClick = { showChapterList = true },
                             enabled = chapters.isNotEmpty(),
                             modifier = Modifier.size(40.dp)
                         ) {
@@ -303,29 +320,6 @@ internal fun ReadiumCompactAudioPlayer(
                                     "Select audiobook chapter"
                                 }
                             )
-                        }
-                        DropdownMenu(
-                            expanded = chapterMenuExpanded,
-                            onDismissRequest = { chapterMenuExpanded = false }
-                        ) {
-                            chapters.forEachIndexed { index, chapter ->
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            chapter.title.ifBlank { "Chapter ${index + 1}" },
-                                            fontWeight = if (index == activeChapterIndex) {
-                                                FontWeight.Bold
-                                            } else {
-                                                FontWeight.Normal
-                                            }
-                                        )
-                                    },
-                                    onClick = {
-                                        chapterMenuExpanded = false
-                                        current.seekToAbsolutePosition(chapter.startMs)
-                                    }
-                                )
-                            }
                         }
                     }
                     IconButton(
@@ -389,12 +383,24 @@ internal fun ReadiumCompactAudioPlayer(
             }
         }
     }
+
+    if (showChapterList) {
+        FullPlayerChapterListSheet(
+            chapters = chapters,
+            activeChapterIndex = activeChapterIndex,
+            onChapterSelected = { chapter ->
+                current.seekToAbsolutePosition(chapter.startMs)
+                showChapterList = false
+            },
+            onClose = { showChapterList = false }
+        )
+    }
 }
 
-private fun formatPlaybackSpeed(speed: Double): String =
+internal fun formatPlaybackSpeed(speed: Double): String =
     if (speed % 1.0 == 0.0) speed.toInt().toString() else speed.toString()
 
-private fun formatPlaybackTime(millis: Long): String {
+internal fun formatPlaybackTime(millis: Long): String {
     val totalSeconds = (millis / 1000L).coerceAtLeast(0L)
     val hours = totalSeconds / 3600L
     val minutes = (totalSeconds % 3600L) / 60L
@@ -407,10 +413,12 @@ private fun formatPlaybackTime(millis: Long): String {
 }
 
 @Composable
-private fun CompactAudiobookCover(
+internal fun CompactAudiobookCover(
     book: BookSummary,
     coverLoader: suspend (BookSummary) -> ByteArray?,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    coverHeight: androidx.compose.ui.unit.Dp? = 72.dp
 ) {
     val bitmap by produceState<Bitmap?>(null, book.id, book.coverUrl, book.updatedAtMillis) {
         value = runCatching { coverLoader(book) }
@@ -419,8 +427,8 @@ private fun CompactAudiobookCover(
             ?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
     }
     Box(
-        modifier = Modifier
-            .height(72.dp)
+        modifier = modifier
+            .then(coverHeight?.let(Modifier::height) ?: Modifier)
             .aspectRatio(book.coverAspectRatio.widthToHeight)
             .background(
                 color = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
@@ -161,6 +161,14 @@ fun BookOrbitApp(
     onDownloadReleaseUpdate: (ReleaseUpdate) -> Unit = {}
 ) {
     val releaseUpdate by coordinator.releaseUpdate.collectAsState()
+    val fullAudioPlayerBook by coordinator.fullAudioPlayerBook.collectAsState()
+    val fullPlayerRequest = audioPlaybackController?.fullPlayerRequest?.collectAsState()?.value
+    LaunchedEffect(fullPlayerRequest?.sequence) {
+        fullPlayerRequest?.let { request ->
+            coordinator.openAudioPlayer(request.book)
+            requireNotNull(audioPlaybackController).consumeFullPlayerRequest(request.sequence)
+        }
+    }
     Box(modifier = Modifier.fillMaxSize()) {
         BookOrbitDestination(
             screen = screen,
@@ -169,16 +177,32 @@ fun BookOrbitApp(
             appPreferences = appPreferences,
             onAppPreferencesChange = onAppPreferencesChange,
             releaseCheckStatus = coordinator.releaseCheckStatus.collectAsState().value,
-            onCheckForUpdates = { coordinator.checkForAppUpdate(forceShow = true) }
+            onCheckForUpdates = { coordinator.checkForAppUpdate(forceShow = true) },
+            showCompactAudioPlayer = fullAudioPlayerBook == null
         )
-        if (screen !is AppScreen.Browser) audioPlaybackController?.let { controller ->
+        if (screen !is AppScreen.Browser && fullAudioPlayerBook == null) audioPlaybackController?.let { controller ->
             ReadiumCompactAudioPlayer(
                 controller = controller,
                 onClosed = coordinator::onAudioPlaybackClosed,
-                onCoverClick = controller::requestBookDetail,
+                onCoverClick = coordinator::openAudioPlayer,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
+            )
+        }
+        if (fullAudioPlayerBook != null) audioPlaybackController?.let { controller ->
+            ReadiumFullAudioPlayer(
+                controller = controller,
+                onCollapse = coordinator::closeAudioPlayer,
+                onBookDetails = { selectedBook ->
+                    controller.requestBookDetail(selectedBook)
+                    coordinator.closeAudioPlayer()
+                },
+                onClosePlayer = coordinator::closeAudioPlayer,
+                loadSessionHistory = coordinator::loadAudiobookSessionHistory,
+                clearSessionHistory = coordinator::clearAudiobookSessionHistory,
+                loadServerReadingSessions = coordinator::loadBookReadingSessions,
+                loadServerReadingAttempts = coordinator::loadBookReadingAttempts
             )
         }
         releaseUpdate?.let { update ->
@@ -239,7 +263,8 @@ private fun BookOrbitDestination(
     appPreferences: AppPreferences,
     onAppPreferencesChange: (AppPreferences) -> Unit,
     releaseCheckStatus: ReleaseCheckStatus,
-    onCheckForUpdates: () -> Unit
+    onCheckForUpdates: () -> Unit,
+    showCompactAudioPlayer: Boolean
 ) {
     when (screen) {
         AppScreen.Loading -> LoadingScreen()
@@ -328,12 +353,12 @@ private fun BookOrbitDestination(
             onBookDetailRequestConsumed = { sequence ->
                 audioPlaybackController?.consumeBookDetailRequest(sequence)
             },
-            bottomOverlay = audioPlaybackController?.let { controller ->
+            bottomOverlay = audioPlaybackController?.takeIf { showCompactAudioPlayer }?.let { controller ->
                 {
                     ReadiumCompactAudioPlayer(
                         controller = controller,
                         onClosed = coordinator::onAudioPlaybackClosed,
-                        onCoverClick = controller::requestBookDetail
+                        onCoverClick = coordinator::openAudioPlayer
                     )
                 }
             }

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitHomeScreen.kt
@@ -854,10 +854,12 @@ internal fun NativeLibraryBrowserScreen(
     var browserRoute by rememberSaveable(stateSaver = BrowserRouteSaver) {
         mutableStateOf(BrowserRouteSnapshot())
     }
+    var openSessionHistoryRequest by rememberSaveable { mutableStateOf(false) }
     val selectedBookProperty = object : ReadWriteProperty<Any?, BookSummary?> {
         override fun getValue(thisRef: Any?, property: KProperty<*>): BookSummary? =
             resolveSelectedBook(listOf(state.books, state.homeBooks, filteredBooks), browserRoute.selectedBook)
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: BookSummary?) {
+            openSessionHistoryRequest = false
             browserRoute = browserRoute.copy(selectedBook = value?.let(::bookSelectionSnapshot))
         }
     }
@@ -921,6 +923,7 @@ internal fun NativeLibraryBrowserScreen(
         selectedSeriesKey = null
         selectedAuthor = null
         selectedBook = request.book
+        openSessionHistoryRequest = request.openSessionHistory
         onBookDetailRequestConsumed(request.sequence)
     }
     val requestDownload: (BookSummary) -> Unit = { book ->
@@ -1483,6 +1486,7 @@ internal fun NativeLibraryBrowserScreen(
                 )
                 selectedBook != null -> BookDetails(
                     book = selectedBook!!,
+                    openSessionHistory = openSessionHistoryRequest,
                     state = state,
                     modifier = Modifier.padding(padding),
                     coverLoader = coverLoader,
@@ -5756,6 +5760,7 @@ private fun LibraryBookCard(
 @Composable
 private fun BookDetails(
     book: BookSummary,
+    openSessionHistory: Boolean,
     state: BrowserState,
     modifier: Modifier,
     coverLoader: suspend (BookSummary) -> ByteArray?,
@@ -5862,8 +5867,8 @@ private fun BookDetails(
     )
     val isDownloading = displayBook.fileId != null && displayBook.fileId in state.downloadingFileIds
     val showSessionHistoryButton = showAudiobookSessionHistoryButton(displayBook)
-    var showSessionHistory by remember(displayBook.id, displayBook.fileId) {
-        mutableStateOf(false)
+    var showSessionHistory by remember(displayBook.id, displayBook.fileId, openSessionHistory) {
+        mutableStateOf(openSessionHistory)
     }
     var sessionHistory by remember(displayBook.id, displayBook.fileId) {
         mutableStateOf<List<AudiobookSessionEvent>>(emptyList())
@@ -6459,7 +6464,7 @@ private fun BookDetails(
 }
 
 @Composable
-private fun AudiobookSessionHistory(
+internal fun AudiobookSessionHistory(
     bookTitle: String,
     events: List<AudiobookSessionEvent>,
     isLoadingServerReadingHistory: Boolean,
@@ -7247,7 +7252,7 @@ private fun DetailMetadataGroup(title: String, entries: List<Pair<String, String
 }
 
 @Composable
-private fun FullScreenCoverViewer(
+internal fun FullScreenCoverViewer(
     book: BookSummary,
     coverLoader: suspend (BookSummary) -> ByteArray?,
     onDismiss: () -> Unit

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
@@ -473,7 +473,27 @@ private suspend fun awaitMedia3Ready(player: Player): PlaybackException? {
 
 internal data class AudioBookDetailRequest(
     val sequence: Long,
+    val book: BookSummary,
+    val openSessionHistory: Boolean = false
+)
+
+internal data class AudioFullPlayerRequest(
+    val sequence: Long,
     val book: BookSummary
+)
+
+internal enum class AudioSleepTimerOption(val label: String, val durationMs: Long?) {
+    OFF("Off", null),
+    END_OF_CHAPTER("End of chapter", null),
+    FIFTEEN_MINUTES("15 minutes", 15 * 60_000L),
+    THIRTY_MINUTES("30 minutes", 30 * 60_000L),
+    FORTY_FIVE_MINUTES("45 minutes", 45 * 60_000L),
+    SIXTY_MINUTES("60 minutes", 60 * 60_000L)
+}
+
+internal data class AudioSleepTimerState(
+    val option: AudioSleepTimerOption = AudioSleepTimerOption.OFF,
+    val remainingMs: Long? = null
 )
 
 internal enum class AudioPlaybackPreparationState {
@@ -848,6 +868,15 @@ class ReadiumAudioPlaybackController internal constructor(
     internal val bookDetailRequest: StateFlow<AudioBookDetailRequest?> =
         mutableBookDetailRequest.asStateFlow()
     private var bookDetailRequestSequence = 0L
+    private val mutableFullPlayerRequest = MutableStateFlow<AudioFullPlayerRequest?>(null)
+    internal val fullPlayerRequest: StateFlow<AudioFullPlayerRequest?> =
+        mutableFullPlayerRequest.asStateFlow()
+    private var fullPlayerRequestSequence = 0L
+    private val mutableSleepTimer = MutableStateFlow(AudioSleepTimerState())
+    internal val sleepTimer: StateFlow<AudioSleepTimerState> = mutableSleepTimer.asStateFlow()
+    private var sleepTimerJob: Job? = null
+    private val mutablePlayerLocked = MutableStateFlow(false)
+    internal val playerLocked: StateFlow<Boolean> = mutablePlayerLocked.asStateFlow()
 
     fun setProgressListener(
         listener: (BookSummary, Long, Float?, ReaderLaunchMode) -> Unit
@@ -877,15 +906,69 @@ class ReadiumAudioPlaybackController internal constructor(
 
     internal suspend fun loadCover(book: BookSummary): ByteArray? = coverLoader?.invoke(book)
 
-    internal fun requestBookDetail(book: BookSummary) {
+    internal fun requestBookDetail(book: BookSummary, openSessionHistory: Boolean = false) {
         bookDetailRequestSequence += 1L
-        mutableBookDetailRequest.value = AudioBookDetailRequest(bookDetailRequestSequence, book)
+        mutableBookDetailRequest.value = AudioBookDetailRequest(
+            sequence = bookDetailRequestSequence,
+            book = book,
+            openSessionHistory = openSessionHistory
+        )
     }
 
     internal fun consumeBookDetailRequest(sequence: Long) {
         if (mutableBookDetailRequest.value?.sequence == sequence) {
             mutableBookDetailRequest.value = null
         }
+    }
+
+    internal fun requestFullPlayer(book: BookSummary) {
+        fullPlayerRequestSequence += 1L
+        mutableFullPlayerRequest.value = AudioFullPlayerRequest(fullPlayerRequestSequence, book)
+    }
+
+    internal fun consumeFullPlayerRequest(sequence: Long) {
+        if (mutableFullPlayerRequest.value?.sequence == sequence) {
+            mutableFullPlayerRequest.value = null
+        }
+    }
+
+    internal fun setSleepTimer(option: AudioSleepTimerOption) {
+        sleepTimerJob?.cancel()
+        if (option == AudioSleepTimerOption.OFF) {
+            mutableSleepTimer.value = AudioSleepTimerState()
+            return
+        }
+        sleepTimerJob = scope.launch {
+            val session = binder().session.value
+            val durationMs = option.durationMs ?: session?.let { current ->
+                val positionMs = current.absolutePositionMs()
+                val chapterEndMs = audiobookChapterEndMs(current.book.audioChapters, positionMs)
+                    ?: current.totalDurationMs()
+                chapterEndMs
+                    .minus(positionMs)
+                    .coerceAtLeast(0L)
+            }
+            if (durationMs == null || durationMs <= 0L) {
+                mutableSleepTimer.value = AudioSleepTimerState()
+                return@launch
+            }
+            val timerDurationMs = requireNotNull(durationMs)
+            var remainingMs = timerDurationMs
+            mutableSleepTimer.value = AudioSleepTimerState(option, remainingMs)
+            while (isActive && remainingMs > 0L) {
+                delay(1_000L)
+                remainingMs = (remainingMs - 1_000L).coerceAtLeast(0L)
+                mutableSleepTimer.value = AudioSleepTimerState(option, remainingMs)
+            }
+            if (isActive) {
+                binder().session.value?.player?.pause()
+                mutableSleepTimer.value = AudioSleepTimerState()
+            }
+        }
+    }
+
+    internal fun setPlayerLocked(locked: Boolean) {
+        mutablePlayerLocked.value = locked
     }
 
     internal suspend fun session(): StateFlow<ReadiumAudioPlaybackService.Session?> = binder().session
@@ -1144,6 +1227,7 @@ class ReadiumAudioPlaybackController internal constructor(
             playbackStateListener = null
             lastRecordedIsPlaying = null
             serviceBinder.stop()
+            mutablePlayerLocked.value = false
         }
     }
 

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayerOverlay.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayerOverlay.kt
@@ -29,7 +29,7 @@ internal fun FragmentActivity.addReadiumAudioPlayerOverlay(
                         }
                     },
                     onCoverClick = { book ->
-                        controller.requestBookDetail(book)
+                        controller.requestFullPlayer(book)
                         finish()
                     }
                 )

--- a/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
@@ -29,6 +29,41 @@ class AppCoordinatorTest {
     )
 
     @Test
+    fun `full audio player overlays current browser screen and dismisses without navigation`() = runTest {
+        val audiobook = book.copy(
+            id = "audio-1",
+            fileId = "audio-file-1",
+            title = "Sample Audiobook",
+            mediaKind = MediaKind.AUDIO
+        )
+        val repository = FakeBookOrbitDataSource(
+            cachedBrowserState = BrowserState(
+                serverUrl = serverUrl,
+                libraries = listOf(library),
+                selectedLibraryId = library.id,
+                books = listOf(book, audiobook)
+            ),
+            loadLibrariesResult = listOf(library),
+            loadBooksResult = listOf(book, audiobook)
+        )
+        val coordinator = AppCoordinator(repository, StandardTestDispatcher(testScheduler))
+
+        coordinator.loadBrowser()
+        advanceUntilIdle()
+        val origin = coordinator.screen.value
+
+        coordinator.openAudioPlayer(audiobook)
+
+        assertEquals(origin, coordinator.screen.value)
+        assertEquals(audiobook, coordinator.fullAudioPlayerBook.value)
+
+        coordinator.closeAudioPlayer()
+
+        assertEquals(origin, coordinator.screen.value)
+        assertNull(coordinator.fullAudioPlayerBook.value)
+    }
+
+    @Test
     fun `loadBrowser restores persisted interrupted download as failed metadata row`() = runTest {
         val interrupted = DownloadRecord(
             serverUrl = serverUrl,

--- a/app/src/test/java/com/vangeaux/lagrange/AppPreferencesStoreTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AppPreferencesStoreTest.kt
@@ -15,6 +15,13 @@ class AppPreferencesStoreTest {
     }
 
     @Test
+    fun audioSkipIntervalsNormalizeToSupportedValues() {
+        assertEquals(5, normalizeAudioSkipSeconds(1))
+        assertEquals(10, normalizeAudioSkipSeconds(12))
+        assertEquals(60, normalizeAudioSkipSeconds(90))
+    }
+
+    @Test
     fun `stored app theme values round trip and invalid values follow system`() {
         AppThemeMode.values().forEach { value ->
             assertEquals(value, appThemeModeFromStorage(appThemeModeStorageValue(value)))

--- a/app/src/test/java/com/vangeaux/lagrange/ReadiumAudioPlaybackTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/ReadiumAudioPlaybackTest.kt
@@ -219,4 +219,30 @@ class ReadiumAudioPlaybackTest {
         assertEquals(10.seconds, configuration.seekBackwardIncrement)
         assertEquals(30.seconds, configuration.seekForwardIncrement)
     }
+
+    @Test
+    fun audiobookChapterBoundsUseTheNextChapterOrTotalDuration() {
+        val chapters = listOf(
+            AudiobookChapter("Opening", 0L),
+            AudiobookChapter("Middle", 100_000L),
+            AudiobookChapter("Ending", 250_000L)
+        )
+
+        assertEquals(100_000L to 250_000L, audiobookChapterBounds(chapters, 150_000L, 400_000L))
+        assertEquals(250_000L to 400_000L, audiobookChapterBounds(chapters, 300_000L, 400_000L))
+        assertEquals(250_000L, audiobookChapterEndMs(chapters, 150_000L))
+        assertEquals(null, audiobookChapterEndMs(chapters, 300_000L))
+    }
+
+    @Test
+    fun audiobookChapterBoundsRejectUnknownDuration() {
+        assertEquals(
+            null,
+            audiobookChapterBounds(
+                listOf(AudiobookChapter("Opening", 0L)),
+                positionMs = 0L,
+                totalDurationMs = 0L
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Closes #68.

It took me a while to fit all of the requested features into the big player, but everything is now implemented and behaving as intended.

- Adds a full-screen audiobook player while preserving the existing playback service.
- Adds chapter previous/next navigation, chapter seeking, configurable skip intervals, playback speed, and sleep timer controls.
- Adds lock mode, session history, cover viewing, and portrait/landscape responsive layouts.
- Preserves the exact browser route beneath the player; minimize and Close do not implicitly navigate.
- Uses one shared Material 3 chapter sheet for compact and full players, respecting Android navigation-bar geometry.
- Keeps Chapter, Speed, and Sleep visible with grouped responsive sizing and usable landscape touch targets.
- Adds centered seek labels and chapter-title marquee scrolling when titles overflow.

## Verification

- `./gradlew --no-daemon --console=plain :app:testDebugUnitTest :app:lintDebug :app:assembleDebugAndroidTest`
- Production and Android-test Kotlin compilation passed.
- Debug APK assembly passed.
- `git diff --check` passed with CRLF handling.
- User-confirmed manual validation of the player and responsive landscape layout.
- No connected Android device was available for assistant-side instrumentation execution.

Release inclusion is expected in the coming days.
