### PR TITLE
fix: isolate account state during logout

### DIFF
--- a/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationQueueStore.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AnnotationMutationQueueStore.kt
@@ -203,6 +203,10 @@ internal class AnnotationLocalIdMappingStore private constructor(
         writeUnlocked(current)
     }
 
+    suspend fun clear() = mutex.withLock {
+        if (file.exists()) file.delete()
+    }
+
     private fun readUnlocked(): Map<String, String> {
         if (!file.exists()) return emptyMap()
         return runCatching {

--- a/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
@@ -198,7 +198,9 @@ class AppCoordinator internal constructor(
     private val queuedProgressByTarget = mutableMapOf<BookProgressKey, PendingProgress>()
     private var pendingPostLoginDestination: PostLoginDestination? = null
     private var allowCachedLoginFallback = true
+    private var acceptAudioProgress = true
     private var audioPlaybackOpener: (suspend (ReaderState, Boolean) -> Boolean)? = null
+    private var audioPlaybackCloser: (suspend () -> Unit)? = null
     private var audioSessionHistoryOpener: ((BookSummary, Long) -> Unit)? = null
     private var releaseCheckInFlight = false
     private var dismissedReleaseTag: String? = null
@@ -206,6 +208,10 @@ class AppCoordinator internal constructor(
 
     fun setAudioPlaybackOpener(opener: suspend (ReaderState, Boolean) -> Boolean) {
         audioPlaybackOpener = opener
+    }
+
+    internal fun setAudioPlaybackCloser(closer: suspend () -> Unit) {
+        audioPlaybackCloser = closer
     }
 
     internal fun setSessionHistoryStore(store: AudiobookSessionHistoryStore) {
@@ -369,7 +375,10 @@ class AppCoordinator internal constructor(
 
     fun changeServer(serverUrl: String) {
         scope.launch {
+            acceptAudioProgress = false
             val oldServerUrl = repository.getServerUrl().orEmpty()
+            _fullAudioPlayerBook.value = null
+            runCatching { audioPlaybackCloser?.invoke() }
             resetTransientState(clearBrowserState = true)
             allowCachedLoginFallback = false
             sessionHistoryStore?.clearServer(oldServerUrl)
@@ -388,7 +397,10 @@ class AppCoordinator internal constructor(
 
     fun clearServer() {
         scope.launch {
+            acceptAudioProgress = false
             val oldServerUrl = repository.getServerUrl().orEmpty()
+            _fullAudioPlayerBook.value = null
+            runCatching { audioPlaybackCloser?.invoke() }
             resetTransientState(clearBrowserState = true)
             sessionHistoryStore?.clearServer(oldServerUrl)
             repository.clearServer()
@@ -510,6 +522,11 @@ class AppCoordinator internal constructor(
 
     fun signOut() {
         scope.launch {
+            acceptAudioProgress = false
+            val serverUrl = repository.getServerUrl().orEmpty()
+            _fullAudioPlayerBook.value = null
+            runCatching { audioPlaybackCloser?.invoke() }
+            sessionHistoryStore?.clearServer(serverUrl)
             resetTransientState(clearBrowserState = true)
             allowCachedLoginFallback = false
             repository.clearSession()
@@ -597,6 +614,7 @@ class AppCoordinator internal constructor(
         catalogLoadJob?.cancel()
         catalogLoadJob = scope.launch {
             val serverUrl = repository.getServerUrl().orEmpty()
+            acceptAudioProgress = true
             showStartup("Loading libraries…")
             restoredInterruptedDownloads = runCatching {
                 repository.loadInterruptedDownloads().associateBy { it.fileId }
@@ -1614,6 +1632,7 @@ class AppCoordinator internal constructor(
     }
 
     fun onProgress(book: BookSummary, position: Long, pageIndex: Int, progressPercent: Float?) {
+        if (!acceptAudioProgress) return
         if ((_screen.value as? AppScreen.Reader)?.readerState?.launchMode == ReaderLaunchMode.PREVIEW) {
             return
         }
@@ -1654,7 +1673,10 @@ class AppCoordinator internal constructor(
                     )
                 )
             }
-            if (ProgressQueuePolicy.shouldQueue(progress.toSnapshot(), queuedProgressByTarget[key]?.toSnapshot())) {
+            if (
+                acceptAudioProgress &&
+                    ProgressQueuePolicy.shouldQueue(progress.toSnapshot(), queuedProgressByTarget[key]?.toSnapshot())
+            ) {
                 queueProgress(key, progress)
             }
         }

--- a/app/src/main/java/com/vangeaux/lagrange/AppGraph.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppGraph.kt
@@ -31,6 +31,10 @@ class AppGraph private constructor(
         coordinator.setAudioPlaybackOpener { state, playWhenReady ->
             controller.restorePersistedSession(state, playWhenReady)
         }
+        coordinator.setAudioPlaybackCloser {
+            controller.discardPendingOutboundSession()
+            controller.close()
+        }
         coordinator.setAudioSessionHistoryOpener(controller::openFromSessionHistory)
     }
 

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
@@ -178,9 +178,14 @@ fun BookOrbitApp(
             onAppPreferencesChange = onAppPreferencesChange,
             releaseCheckStatus = coordinator.releaseCheckStatus.collectAsState().value,
             onCheckForUpdates = { coordinator.checkForAppUpdate(forceShow = true) },
-            showCompactAudioPlayer = fullAudioPlayerBook == null
+            showCompactAudioPlayer = screen is AppScreen.Browser && fullAudioPlayerBook == null
         )
-        if (screen !is AppScreen.Browser && fullAudioPlayerBook == null) audioPlaybackController?.let { controller ->
+        if (
+            screen !is AppScreen.Browser &&
+                screen !is AppScreen.Login &&
+                screen !is AppScreen.ServerSetup &&
+                fullAudioPlayerBook == null
+        ) audioPlaybackController?.let { controller ->
             ReadiumCompactAudioPlayer(
                 controller = controller,
                 onClosed = coordinator::onAudioPlaybackClosed,

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
@@ -399,9 +399,24 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
     }
 
     override suspend fun clearSession() {
+        val workManager = WorkManager.getInstance(context)
+        workManager.cancelUniqueWork("bookorbit-progress-sync")
+        workManager.cancelUniqueWork("bookorbit-reading-session-sync")
+        workManager.cancelUniqueWork("bookorbit-annotation-sync")
         OfflineCacheSyncWorker.cancel(context)
+        // DownloadStore is device-shared local content; do not remove completed files on logout.
+        queueStore.clear()
+        readingSessionQueueStore.clear()
+        annotationMutationQueueStore.clear()
+        annotationLocalIdMappingStore.clear()
+        lastSyncedProgressStore.clear()
+        browserSnapshotStore.clear()
+        catalogSnapshotStore.clear()
+        libraryCatalogStore.clear()
+        bookDetailCacheStore.clear()
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.ACCESS_TOKEN)
+            prefs.remove(Keys.SELECTED_LIBRARY_ID)
         }
         activeReaderStore.clear()
         epubReaderPositionStore.clear()

--- a/app/src/main/java/com/vangeaux/lagrange/CatalogSnapshotStore.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/CatalogSnapshotStore.kt
@@ -35,6 +35,10 @@ class CatalogSnapshotStore(context: Context) {
         readPage(serverUrl, "authorBooks", pageKey(authorId, page))
     }
 
+    suspend fun clear() = mutex.withLock {
+        if (file.exists()) file.delete()
+    }
+
     private fun savePage(serverUrl: String, catalog: String, key: String, payload: String) {
         val root = readRoot()
         val servers = root.optJSONObject("servers") ?: JSONObject().also { root.put("servers", it) }

--- a/app/src/main/java/com/vangeaux/lagrange/LibraryCatalogStore.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/LibraryCatalogStore.kt
@@ -140,6 +140,22 @@ internal interface LibraryCatalogDao {
     @Query("DELETE FROM library_catalog_jump_buckets WHERE serverUrl = :serverUrl AND libraryId = :libraryId")
     suspend fun deleteJumpBuckets(serverUrl: String, libraryId: String)
 
+    @Query("DELETE FROM library_catalog_books")
+    suspend fun clearAllBooks()
+
+    @Query("DELETE FROM library_catalog_metadata")
+    suspend fun clearAllMetadata()
+
+    @Query("DELETE FROM library_catalog_jump_buckets")
+    suspend fun clearAllJumpBuckets()
+
+    @Transaction
+    suspend fun clearAll() {
+        clearAllBooks()
+        clearAllMetadata()
+        clearAllJumpBuckets()
+    }
+
     @Query(
         """
         UPDATE library_catalog_books
@@ -290,6 +306,10 @@ internal class LibraryCatalogStore(context: Context) {
         reconcileMutex.withLock {
             dao.updateLocalPath(serverUrl, bookId, localPath)
         }
+
+    suspend fun clear() = reconcileMutex.withLock {
+        dao.clearAll()
+    }
 
     suspend fun replace(
         serverUrl: String,

--- a/app/src/main/java/com/vangeaux/lagrange/ReadingSessionReporter.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadingSessionReporter.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 internal class ReadingSessionReporter(
@@ -50,6 +51,11 @@ internal class ReadingSessionReporter(
     fun end(progressPercent: Float?, atMillis: Long = System.currentTimeMillis()) {
         if (!enabled) return
         tracker.end(progressPercent, atMillis)?.let(::enqueue)
+    }
+
+    fun disable() {
+        enabled = false
+        scope.cancel()
     }
 
     private fun enqueue(payloads: List<ReadingSessionPayload>) {

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
@@ -1231,6 +1231,10 @@ class ReadiumAudioPlaybackController internal constructor(
         }
     }
 
+    internal fun discardPendingOutboundSession() {
+        readingSessionReporter?.disable()
+    }
+
     private fun recordSessionEvent(
         session: ReadiumAudioPlaybackService.Session,
         isPlaying: Boolean

--- a/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
@@ -2308,6 +2308,34 @@ class AppCoordinatorTest {
     }
 
     @Test
+    fun `sign out closes audio playback and dismisses full player before showing login`() = runTest {
+        val repository = FakeBookOrbitDataSource(
+            serverUrl = serverUrl,
+            sessionState = SessionState.Unauthenticated
+        )
+        val coordinator = AppCoordinator(repository, StandardTestDispatcher(testScheduler))
+        var playbackClosed = false
+        coordinator.setAudioPlaybackCloser { playbackClosed = true }
+        coordinator.openAudioPlayer(book.copy(mediaKind = MediaKind.AUDIO))
+
+        coordinator.signOut()
+        advanceUntilIdle()
+
+        assertTrue(playbackClosed)
+        assertNull(coordinator.fullAudioPlayerBook.value)
+        assertTrue(coordinator.screen.value is AppScreen.Login)
+
+        coordinator.onAudioPlaybackProgress(
+            book = book.copy(mediaKind = MediaKind.AUDIO),
+            position = 12_000L,
+            progressPercent = 0.2f,
+            launchMode = ReaderLaunchMode.NORMAL
+        )
+        advanceUntilIdle()
+        assertTrue(repository.queuedProgress.isEmpty())
+    }
+
+    @Test
     fun `server sign-in can open and close without changing native login state`() = runTest {
         val repository = FakeBookOrbitDataSource(sessionState = SessionState.Unauthenticated)
         val coordinator = AppCoordinator(repository, StandardTestDispatcher(testScheduler))

--- a/app/src/test/java/com/vangeaux/lagrange/LastSyncedProgressStoreTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/LastSyncedProgressStoreTest.kt
@@ -87,4 +87,25 @@ class LastSyncedProgressStoreTest {
         assertNull(store.read(target.progressKey()))
         assertEquals(other.progressPercent, store.read(other.progressKey())?.progressPercent)
     }
+
+    @Test
+    fun `clear removes all synchronized updates`() = runBlocking {
+        val store = LastSyncedProgressStore(Files.createTempDirectory("last-synced-progress-clear").toFile())
+        val update = ProgressUpdate(
+            id = "clear-1",
+            serverUrl = "https://example.test",
+            bookId = "book-1",
+            fileId = "file-1",
+            mediaKind = MediaKind.EPUB,
+            positionMs = 100L,
+            pageIndex = 1,
+            progressPercent = 10f,
+            updatedAtMillis = 1L
+        )
+        store.save(update)
+
+        store.clear()
+
+        assertNull(store.read(update.progressKey()))
+    }
 }

--- a/app/src/test/java/com/vangeaux/lagrange/ProgressQueueStoreTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/ProgressQueueStoreTest.kt
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ProgressQueueStoreTest {
@@ -281,6 +282,16 @@ class ProgressQueueStoreTest {
         store.removeForBook("https://example.test", "book-1")
 
         assertEquals(listOf("other-book", "other-server"), store.readAll().map { it.id })
+    }
+
+    @Test
+    fun `clear removes all pending updates`() = runBlocking {
+        val store = ProgressQueueStore(Files.createTempDirectory("progress-queue-clear").toFile())
+        store.enqueue(update("clear-1", "book-1", "file-1", MediaKind.EPUB, updatedAtMillis = 1L))
+
+        store.clear()
+
+        assertTrue(store.readAll().isEmpty())
     }
 
     private fun update(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ Lagrange is a native Android client for BookOrbit focused on reading, listening,
 ## Data and synchronization rules
 
 - Server identity is part of local cache and persistence boundaries; do not mix records between configured servers.
+- Explicit logout, server change, and server removal close the Media3 audiobook service before credentials are cleared, disable late audio-progress callbacks, cancel outbound sync workers, and purge queued progress, reading-session, annotation, catalog, browser-snapshot, detail-cache, and exact-reader state. Downloaded media files remain device-shared assets and are not removed by session cleanup; Local books may therefore appear for another account on the same server/device, without carrying over the previous account's reading state or metadata.
 - Completed local-copy records are separate from active/failed download attempts. Failed first downloads remain remote-only; failed updates preserve the prior completed copy.
 - Local exact-position audiobook history remains authoritative for seeking. Server sessions/reading attempts supplement it as analytics context.
 - Pending progress replay is outbound protection. It does not replace authoritative inbound progress hydration on normal online opens.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,6 +142,8 @@ For regression testing, verify chapter selection and automatic advancement acros
 
 Verify password login, `/api/v1/auth/me` bootstrap, sign-out/session reset, session-expiry recovery, and pending-destination recovery. The interim server-hosted sign-in WebView is distinct from native AppAuth. Native AppAuth requires deployed BookOrbit mobile-redirect support and separate provider/device validation.
 
+For logout and account-switch regression, start audiobook playback, verify that explicit logout immediately removes the compact/full player and foreground playback notification before the Login screen is usable, then sign in as a different account on the same server. Confirm the previous account's queued progress, reading-session events, annotations, cached catalog/detail state, and exact reader positions are not replayed or displayed for the new account. Confirm completed downloaded media remains available and appears in Local books for the new account, while its progress/status reflects only the new account's server state. Verify that same-user background playback still survives ordinary task removal. Repeat from compact playback, full-player playback, paused playback, and while the player is preparing. Automated coverage verifies coordinator teardown and durable progress-store cleanup; physical player, notification, and two-account validation require a connected device or emulator.
+
 ### Foreground WorkManager book downloads (issue #77)
 
 This scenario set is pending manual/device validation; nothing below has been device-confirmed yet. On a connected device or emulator, verify:


### PR DESCRIPTION
## Summary

- Close the audiobook player and playback service during logout, server change, and server removal.
- Prevent late audio progress and reading-session callbacks from crossing an account boundary.
- Purge account-owned progress, session, annotation, catalog, browser, detail, and reader state while preserving downloaded Local books as device-shared media.
- Keep Login and Server Setup free of stale compact-player UI.
- Document the shared Local books policy and account-scoped reading state.

## Verification

- Focused logout/progress tests: 105 tests, 0 skipped, 0 failures, 0 errors.
- `:app:compileDebugKotlin`
- `:app:compileDebugUnitTestKotlin`
- `:app:compileDebugAndroidTestKotlin`
- `:app:lintDebug`
- `:app:assembleDebug`
- `:app:assembleDebugAndroidTest`
- CRLF-aware `git diff --check`
- Fresh debug APK: `app/build/outputs/apk/debug/Lagrange-debug-202608211113.apk`
- No connected device was available for assistant-side instrumentation; the user confirmed the behavior works.

The downloaded media remains available to another account in Local books, while account-specific progress and metadata are cleared.

Closes #88
