### PR TITLE
fix: stop audiobook playback when task is removed

### DIFF
--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
@@ -781,8 +781,8 @@ class ReadiumAudioPlaybackService : MediaSessionService() {
         binder.session.value?.mediaSession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        // Playback intentionally survives removal of the app task.
         super.onTaskRemoved(rootIntent)
+        binder.stop()
     }
 
     override fun onDestroy() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ Lagrange is a native Android client for BookOrbit focused on reading, listening,
 - Repository/data layer: authenticated BookOrbit requests, parsing, server switching, cache fallback, progress/status/rating operations, download reconciliation, and reader preparation.
 - Room/local persistence: server-scoped catalog/download state, active-reader metadata, queued progress, and local audiobook session history.
 - Readium: EPUB, PDF, comic, and local/explicit-download reading paths.
-- Media3/foreground service: connected and local audiobook playback, compact controls, chapters, seeking, speed, sleep timers, and process/task restoration. The service/controller owns playback state and commands; Compose renders the compact or full player without creating a second playback session.
+- Media3/foreground service: connected and local audiobook playback, compact controls, chapters, seeking, speed, sleep timers, and process restoration. The service/controller owns playback state and commands; Compose renders the compact or full player without creating a second playback session. Ordinary app backgrounding and screen lock remain service-owned; Android app-task removal invokes service cleanup, which stops playback, removes the foreground notification, and stops the service.
 - Full audiobook player overlay: `AppCoordinator.fullAudioPlayerBook` overlays the retained browser composition, so minimize and Close dismiss the player without implicitly navigating or losing the exact browser route. Metadata navigation is an explicit separate action.
 
 ## Data and synchronization rules

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -187,6 +187,17 @@ Focused JVM verification for the full-player theme regression:
 
 The user has confirmed the validated reader, media, navigation, and server-session behavior works correctly. Keep these checks as the regression matrix for future changes.
 
+### Audiobook app lifecycle
+
+On a connected Android device or emulator with audiobook playback active, exercise these as separate scenarios:
+
+- **Ordinary backgrounding and screen lock:** switch to another app, then turn the screen off and on. Playback remains owned by the foreground service and continues; returning to Lagrange must reconnect to the existing playback state.
+- **Android app-task removal:** remove Lagrange from the recent-apps/task list. The playback service runs its cleanup path: playback stops, the foreground playback notification is removed, and the service stops. Do not treat this as ordinary backgrounding or screen lock.
+- **Notification dismissal:** dismiss the audiobook playback notification as its own scenario, without removing the app task. Record the resulting playback/service and notification behavior separately; notification dismissal is not a substitute for the task-removal check.
+- **Force-stop:** use Android Settings to force-stop Lagrange, then relaunch it. Treat force-stop as a separate termination path and verify playback and notification state after relaunch; do not report it as evidence for the task-removal contract.
+
+This procedure documents the lifecycle contract; no automated or physical validation result is asserted here.
+
 ### Audiobook seek confirmation (issue #129)
 
 On a connected Android device or emulator with a split-file audiobook available, start playback and exercise each seek bar in compact player, full-player portrait, and full-player landscape states. In each state, test both the overall book bar and the chapter bar: drag/tap to a new position and verify the seek applies immediately, playback continues, and the in-place confirmation offers `Yes, keep position` and `No, go back`. Accept with `Yes, keep position` and verify the new position remains. Repeat a seek, choose `No, go back`, and verify the prior absolute position is restored, including when the requested position crosses a split-file boundary.
@@ -223,7 +234,7 @@ For regression testing, verify chapter selection and automatic advancement acros
 
 Verify password login, `/api/v1/auth/me` bootstrap, sign-out/session reset, session-expiry recovery, and pending-destination recovery. The interim server-hosted sign-in WebView is distinct from native AppAuth. Native AppAuth requires deployed BookOrbit mobile-redirect support and separate provider/device validation.
 
-For logout and account-switch regression, start audiobook playback, verify that explicit logout immediately removes the compact/full player and foreground playback notification before the Login screen is usable, then sign in as a different account on the same server. Confirm the previous account's queued progress, reading-session events, annotations, cached catalog/detail state, and exact reader positions are not replayed or displayed for the new account. Confirm completed downloaded media remains available and appears in Local books for the new account, while its progress/status reflects only the new account's server state. Verify that same-user background playback still survives ordinary task removal. Repeat from compact playback, full-player playback, paused playback, and while the player is preparing. Automated coverage verifies coordinator teardown and durable progress-store cleanup; physical player, notification, and two-account validation require a connected device or emulator.
+For logout and account-switch regression, start audiobook playback, verify that explicit logout immediately removes the compact/full player and foreground playback notification before the Login screen is usable, then sign in as a different account on the same server. Confirm the previous account's queued progress, reading-session events, annotations, cached catalog/detail state, and exact reader positions are not replayed or displayed for the new account. Confirm completed downloaded media remains available and appears in Local books for the new account, while its progress/status reflects only the new account's server state. Verify that same-user background playback still survives ordinary backgrounding or screen lock. Task removal is covered separately below. Repeat from compact playback, full-player playback, paused playback, and while the player is preparing. Automated coverage verifies coordinator teardown and durable progress-store cleanup; physical player, notification, and two-account validation require a connected device or emulator.
 
 ### Foreground WorkManager book downloads (issue #77)
 


### PR DESCRIPTION
## Summary

- Stop the audiobook Media3 service when Android removes the Lagrange app task.
- Reuse the existing service cleanup path to release the player/session, remove the foreground notification, and stop the service.
- Preserve playback during ordinary backgrounding and screen lock.
- Document the separated audiobook lifecycle checks.

Closes #150

## Verification

- `:app:compileDebugKotlin` passed.
- `:app:compileDebugAndroidTestKotlin` passed.
- Focused audiobook playback tests: 17 passed.
- Full JVM suite: 661 passed, 0 failures, 0 errors, 0 skipped.
- `lintDebug` passed with 0 errors and 50 existing warnings.
- Debug and Android-test APK assembly passed.
- No connected device was available for assistant-side instrumentation; the reporter independently confirmed the fix on another device.