### PR TITLE
fix: complete multipart audiobook playback timeline

### DIFF
--- a/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
@@ -1137,10 +1137,14 @@ class AppCoordinator internal constructor(
                     null
                 }
                 val detailForOpen: BookDetailInfo? = when {
-                    launchMode == ReaderLaunchMode.NORMAL && !offlineOpen -> {
-                        runCatching { repository.loadBookDetail(book) }.getOrNull()
+                    book.mediaKind == MediaKind.AUDIO && offlineOpen -> {
+                        repository.loadCachedBookDetail(book)
                     }
-                    book.mediaKind == MediaKind.AUDIO && book.audioChapters.isEmpty() -> {
+                    book.mediaKind == MediaKind.AUDIO -> {
+                        runCatching { repository.loadBookDetail(book) }.getOrNull()
+                            ?: repository.loadCachedBookDetail(book)
+                    }
+                    launchMode == ReaderLaunchMode.NORMAL && !offlineOpen -> {
                         runCatching { repository.loadBookDetail(book) }.getOrNull()
                     }
                     else -> null
@@ -1158,8 +1162,18 @@ class AppCoordinator internal constructor(
                         localPath = book.localPath ?: detailForOpen.book.localPath
                     ) ?: book
                 }
-                val audioFiles = if (book.mediaKind == MediaKind.AUDIO && !offlineOpen) {
-                    AudiobookTimeline.playableAudioFiles(detailForOpen?.availableFiles.orEmpty())
+                val audioFiles = if (book.mediaKind == MediaKind.AUDIO) {
+                    if (offlineOpen) {
+                        AudiobookTimeline.selectedLocalPlaybackAudioFiles(
+                            detailForOpen?.availableFiles.orEmpty(),
+                            book.fileId
+                        )
+                    } else {
+                        AudiobookTimeline.selectedPlaybackAudioFiles(
+                            detailForOpen?.availableFiles.orEmpty(),
+                            book.fileId
+                        )
+                    }
                 } else {
                     emptyList()
                 }
@@ -1176,8 +1190,15 @@ class AppCoordinator internal constructor(
                     book = progressBook,
                     localOnly = offlineOpen
                 )
+                val audioTotalDurationMs = detailForOpen
+                    ?.durationSeconds
+                    ?.takeIf { it > 0L }
+                    ?.let { seconds -> seconds.coerceAtMost(Long.MAX_VALUE / 1_000L) * 1_000L }
                 presentationStarted = true
-                presentReaderState(preparedState, audioFiles)
+                presentReaderState(
+                    preparedState.copy(audioTotalDurationMs = audioTotalDurationMs),
+                    audioFiles
+                )
             }.onFailure { error ->
                 if (error.message == AUDIO_OPEN_CANCELLED_MESSAGE) {
                     return@onFailure

--- a/app/src/main/java/com/vangeaux/lagrange/AudiobookTimeline.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AudiobookTimeline.kt
@@ -12,10 +12,39 @@ object AudiobookTimeline {
     fun playableAudioFiles(options: List<BookFileOption>): List<BookFileOption> =
         options.filter { it.mediaKind == MediaKind.AUDIO && !it.fileId.isNullOrBlank() }
 
-    fun downloadableAudioFiles(options: List<BookFileOption>): List<BookFileOption> =
+    fun playbackAudioFiles(options: List<BookFileOption>): List<BookFileOption> =
         playableAudioFiles(options)
-            .filter { !it.role.equals("supplement", ignoreCase = true) }
+            .filter { file ->
+                file.role.isNullOrBlank() ||
+                    file.role.equals("content", ignoreCase = true) ||
+                    file.role.equals("primary", ignoreCase = true)
+            }
             .distinctBy { it.fileId }
+
+    fun selectedPlaybackAudioFiles(
+        options: List<BookFileOption>,
+        selectedFileId: String?
+    ): List<BookFileOption> {
+        val candidates = playbackAudioFiles(options)
+        val selectedFormat = candidates
+            .firstOrNull { it.fileId == selectedFileId }
+            ?.let(::availableFileGroupFormat)
+        if (selectedFormat != null) {
+            return candidates.filter { availableFileGroupFormat(it) == selectedFormat }
+        }
+        val formats = candidates.map(::availableFileGroupFormat).distinct()
+        return candidates.takeIf { formats.size == 1 }.orEmpty()
+    }
+
+    fun selectedLocalPlaybackAudioFiles(
+        options: List<BookFileOption>,
+        selectedFileId: String?
+    ): List<BookFileOption> = selectedPlaybackAudioFiles(options, selectedFileId).map { option ->
+        option.copy(book = option.book.copy(streamUrl = null))
+    }
+
+    fun downloadableAudioFiles(options: List<BookFileOption>): List<BookFileOption> =
+        playbackAudioFiles(options)
 
     private fun durationMs(file: BookFileOption): Long? = file.durationMs?.takeIf { it > 0 }
 

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitApp.kt
@@ -951,7 +951,9 @@ private fun AudioReader(
                     file = file,
                     streamUrl = streamUrl,
                     initialPositionMs = state.lastKnownPosition,
-                    launchMode = state.launchMode
+                    launchMode = state.launchMode,
+                    audioFiles = state.audioFiles,
+                    aggregateDurationMs = state.audioTotalDurationMs
                 )
             } ?: ReadiumAudioOpenResult.Error(
                 "Audiobook preparation timed out. Try opening it again."

--- a/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/BookOrbitRepository.kt
@@ -265,6 +265,7 @@ interface BookOrbitDataSource {
     suspend fun loadBookCover(book: BookSummary): ByteArray? = null
     suspend fun loadCatalogImage(url: String): ByteArray? = null
     suspend fun loadBookDetail(book: BookSummary): BookDetailInfo? = null
+    suspend fun loadCachedBookDetail(book: BookSummary): BookDetailInfo? = null
     suspend fun loadReaderProgress(
         book: BookSummary,
         availableFiles: List<BookFileOption> = emptyList()
@@ -1302,6 +1303,14 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
         }
     }
 
+    override suspend fun loadCachedBookDetail(book: BookSummary): BookDetailInfo? = withContext(Dispatchers.IO) {
+        bookDetailCacheStore.readLatest(
+            serverUrl = getServerUrl().orEmpty(),
+            bookId = book.id,
+            fileId = book.fileId
+        )
+    }
+
     override suspend fun loadReaderProgress(
         book: BookSummary,
         availableFiles: List<BookFileOption>
@@ -1641,12 +1650,18 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
         val savedBook = savedSession.book
         var bookForRestore = savedBook
         var audioFiles = emptyList<BookFileOption>()
+        var audioTotalDurationMs: Long? = null
         var queuedAudioProgress: ProgressUpdate? = null
         if (!localOnly && savedBook.mediaKind == MediaKind.AUDIO) {
             val detail = runCatching { loadBookDetail(savedBook) }.getOrNull()
+            audioTotalDurationMs = detail?.durationSeconds
+                ?.takeIf { it > 0L }
+                ?.let { seconds -> seconds.coerceAtMost(Long.MAX_VALUE / 1_000L) * 1_000L }
             audioFiles = detail
                 ?.availableFiles
-                ?.let(AudiobookTimeline::playableAudioFiles)
+                ?.let { options ->
+                    AudiobookTimeline.selectedPlaybackAudioFiles(options, savedBook.fileId)
+                }
                 .orEmpty()
             if (audioFiles.isNotEmpty()) {
                 val detailBook = requireNotNull(detail).book
@@ -1682,9 +1697,15 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
                 cachedDetail = bookDetailCacheStore.readLatest(serverUrl, savedBook.id, record.fileId)
                 if (cachedDetail != null) break
             }
+            audioTotalDurationMs = cachedDetail?.durationSeconds
+                ?.takeIf { it > 0L }
+                ?.let { seconds -> seconds.coerceAtMost(Long.MAX_VALUE / 1_000L) * 1_000L }
             audioFiles = cachedDetail
                 ?.let { detail ->
-                    AudiobookTimeline.downloadableAudioFiles(detail.availableFiles).map { option ->
+                    AudiobookTimeline.selectedPlaybackAudioFiles(
+                        detail.availableFiles,
+                        savedBook.fileId
+                    ).map { option ->
                         option.copy(
                             book = option.book.copy(
                                 localPath = localPathsByFileId[option.fileId],
@@ -1777,7 +1798,8 @@ class BookOrbitRepository(private val context: Context) : BookOrbitDataSource {
             readerPageIndex = epubPosition?.pageIndex ?: savedBook.readerPageIndex ?: 0,
             progressPercent = restoredProgress.progressPercent,
             launchMode = savedSession.launchMode,
-            audioFiles = audioFiles
+            audioFiles = audioFiles,
+            audioTotalDurationMs = audioTotalDurationMs
         )
     }
 
@@ -3306,7 +3328,12 @@ internal object BookOrbitPayloadParser {
             }
         }
         val summedAudioDurationSeconds = AudiobookTimeline
-            .totalDurationMs(AudiobookTimeline.playableAudioFiles(availableFiles))
+            .totalDurationMs(
+                AudiobookTimeline.selectedPlaybackAudioFiles(
+                    availableFiles,
+                    book.fileId
+                )
+            )
             ?.let { totalMs ->
                 totalMs / 1000L + if (totalMs % 1000L >= 500L) 1L else 0L
             }

--- a/app/src/main/java/com/vangeaux/lagrange/Models.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/Models.kt
@@ -317,7 +317,7 @@ internal fun availableFileGroups(options: List<BookFileOption>): List<AvailableF
         groups
     }
 
-private fun availableFileGroupFormat(option: BookFileOption): String =
+internal fun availableFileGroupFormat(option: BookFileOption): String =
     option.format
             ?.substringAfterLast('/')
             ?.substringBefore(';')
@@ -712,6 +712,7 @@ data class ReaderState(
     val progressPercent: Float? = null,
     val launchMode: ReaderLaunchMode = ReaderLaunchMode.NORMAL,
     val audioFiles: List<BookFileOption> = emptyList(),
+    val audioTotalDurationMs: Long? = null,
     val initialCfi: String? = null,
     val annotationText: String? = null,
     val annotationChapterIndex: Int? = null,

--- a/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/ReadiumAudioPlayback.kt
@@ -19,6 +19,7 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.CommandButton
@@ -229,15 +230,20 @@ internal data class AudiobookMediaItemSpec(
     val localPath: String? = null
 )
 
-internal fun buildAudiobookMediaItemSpecs(files: List<BookFileOption>): List<AudiobookMediaItemSpec> =
-    AudiobookTimeline.downloadableAudioFiles(files).mapNotNull { file ->
+internal data class PreparedAudiobookPlaylist(
+    val files: List<BookFileOption>,
+    val specs: List<AudiobookMediaItemSpec>
+)
+
+internal fun prepareAudiobookPlaylist(files: List<BookFileOption>): PreparedAudiobookPlaylist {
+    val tracks = AudiobookTimeline.downloadableAudioFiles(files).mapNotNull { file ->
         val fileId = file.fileId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
         val localPath = file.localPath?.takeIf { File(it).isFile }
         val streamUrl = file.book.streamUrl?.takeIf { it.isNotBlank() }
             ?: localPath
             ?: return@mapNotNull null
         val mimeType = file.format?.let(::media3AudioMimeType) ?: return@mapNotNull null
-        AudiobookMediaItemSpec(
+        file to AudiobookMediaItemSpec(
             fileId = fileId,
             streamUrl = streamUrl,
             mimeType = mimeType,
@@ -246,6 +252,14 @@ internal fun buildAudiobookMediaItemSpecs(files: List<BookFileOption>): List<Aud
             localPath = localPath
         )
     }
+    return PreparedAudiobookPlaylist(
+        files = tracks.map { it.first },
+        specs = tracks.map { it.second }
+    )
+}
+
+internal fun buildAudiobookMediaItemSpecs(files: List<BookFileOption>): List<AudiobookMediaItemSpec> =
+    prepareAudiobookPlaylist(files).specs
 
 internal fun buildAudiobookMediaItems(files: List<BookFileOption>): List<MediaItem> =
     buildAudiobookMediaItemSpecs(files).map { spec ->
@@ -267,14 +281,19 @@ internal fun resolveAbsolutePositionMs(
     currentFileId: String?,
     currentFilePositionMs: Long
 ): Long {
-    val playableFiles = AudiobookTimeline.playableAudioFiles(audioFiles)
+    val playableFiles = AudiobookTimeline.playbackAudioFiles(audioFiles)
     val fileId = currentFileId ?: return currentFilePositionMs.coerceAtLeast(0L)
     return AudiobookTimeline.fileRelativeToAbsolute(playableFiles, fileId, currentFilePositionMs)
         ?: currentFilePositionMs.coerceAtLeast(0L)
 }
 
-internal fun resolveTotalDurationMs(audioFiles: List<BookFileOption>, fallbackDurationMs: Long): Long {
-    val playableFiles = AudiobookTimeline.playableAudioFiles(audioFiles)
+internal fun resolveTotalDurationMs(
+    audioFiles: List<BookFileOption>,
+    fallbackDurationMs: Long,
+    serverAggregateDurationMs: Long? = null
+): Long {
+    serverAggregateDurationMs?.takeIf { it > 0L }?.let { return it }
+    val playableFiles = AudiobookTimeline.playbackAudioFiles(audioFiles)
     return AudiobookTimeline.totalDurationMs(playableFiles) ?: fallbackDurationMs.coerceAtLeast(0L)
 }
 
@@ -282,17 +301,47 @@ internal fun resolveSeekTarget(
     audioFiles: List<BookFileOption>,
     absolutePositionMs: Long
 ): AudiobookTimelinePosition? {
-    val playableFiles = AudiobookTimeline.playableAudioFiles(audioFiles)
+    val playableFiles = AudiobookTimeline.playbackAudioFiles(audioFiles)
     if (playableFiles.size < 2) return null
     return AudiobookTimeline.absoluteToPosition(playableFiles, absolutePositionMs)
 }
+
+internal fun resolvePlayerSeekTarget(
+    audioFiles: List<BookFileOption>,
+    mediaItemIds: List<String>,
+    absolutePositionMs: Long
+): AudiobookTimelinePosition? {
+    val target = resolveSeekTarget(audioFiles, absolutePositionMs) ?: return null
+    val mediaItemIndex = mediaItemIds.indexOf(target.fileId)
+    return target.takeIf { mediaItemIndex >= 0 }?.copy(fileIndex = mediaItemIndex)
+}
+
+internal fun hasSameAudiobookPlaybackManifest(
+    existing: List<BookFileOption>,
+    requested: List<BookFileOption>
+): Boolean = existing.map { it.fileId } == requested.map { it.fileId }
+
+internal fun resolveInitialAudiobookMediaItemIndex(
+    mediaItemIds: List<String>,
+    initialFileId: String?
+): Int = mediaItemIds.indexOf(initialFileId).let { index ->
+    if (index >= 0) index else 0
+}
+
+internal fun shouldUseSingleFileAudioEngine(
+    localFileAvailable: Boolean,
+    audiobookFileCount: Int
+): Boolean = localFileAvailable && audiobookFileCount < 2
+
+internal fun shouldUsePlaylistMedia3Audio(preparedAudioFileCount: Int): Boolean =
+    preparedAudioFileCount > 0
 
 internal fun activeBookSummaryForActiveFile(
     book: BookSummary,
     audioFiles: List<BookFileOption>,
     currentFileId: String?
 ): BookSummary {
-    val activeFile = AudiobookTimeline.playableAudioFiles(audioFiles)
+    val activeFile = AudiobookTimeline.playbackAudioFiles(audioFiles)
         .firstOrNull { it.fileId == currentFileId }
         ?: return book
     return book.copy(
@@ -323,7 +372,7 @@ internal suspend fun openDirectMedia3Audio(
     recoverAuthentication: suspend () -> Boolean
 ): ReadiumAudioOpenResult {
     val playlistItems = buildAudiobookMediaItems(audioFiles)
-    if (playlistItems.size >= 2) {
+    if (shouldUsePlaylistMedia3Audio(playlistItems.size)) {
         return preparePlaylistMedia3Audio(
             application = application,
             mediaItems = playlistItems,
@@ -335,7 +384,9 @@ internal suspend fun openDirectMedia3Audio(
         )
     }
     val url = streamUrl?.takeIf { it.isNotBlank() }
-        ?: return ReadiumAudioOpenResult.Error("The audiobook has no valid BookOrbit stream.")
+        ?: return ReadiumAudioOpenResult.Error(
+            "No playable downloaded audiobook file is available locally."
+        )
     val mimeType = book.format?.let(::media3AudioMimeType)
         ?: return ReadiumAudioOpenResult.Error("This audiobook format is not supported yet.")
     return prepareDirectMedia3Audio(
@@ -367,15 +418,20 @@ private suspend fun preparePlaylistMedia3Audio(
         .setSeekForwardIncrementMs(AUDIO_SEEK_FORWARD_INCREMENT_MS)
         .setMediaSourceFactory(
             DefaultMediaSourceFactory(application).setDataSourceFactory(
-                AuthenticatedMedia3HttpDataSourceFactory(
-                    headersProvider = headersProvider,
-                    recoverAuthentication = recoverAuthentication
+                DefaultDataSource.Factory(
+                    application,
+                    AuthenticatedMedia3HttpDataSourceFactory(
+                        headersProvider = headersProvider,
+                        recoverAuthentication = recoverAuthentication
+                    )
                 )
             )
         )
         .build()
-    val initialIndex = mediaItems.indexOfFirst { it.mediaId == initialFileId }
-        .let { if (it >= 0) it else 0 }
+    val initialIndex = resolveInitialAudiobookMediaItemIndex(
+        mediaItems.map { it.mediaId },
+        initialFileId
+    )
     player.setMediaItems(mediaItems, initialIndex, initialPositionMs.coerceAtLeast(0L))
     player.prepare()
 
@@ -699,7 +755,8 @@ class ReadiumAudioPlaybackService : MediaSessionService() {
         val launchMode: ReaderLaunchMode,
         val engine: AudioPlaybackEngine,
         val mediaSession: MediaSession,
-        val audioFiles: List<BookFileOption> = emptyList()
+        val audioFiles: List<BookFileOption> = emptyList(),
+        val aggregateDurationMs: Long? = null
     ) {
         val player: Player
             get() = engine.player
@@ -712,16 +769,24 @@ class ReadiumAudioPlaybackService : MediaSessionService() {
 
         fun currentFilePositionMs(): Long = player.currentPosition.coerceAtLeast(0L)
 
-        fun totalDurationMs(): Long = resolveTotalDurationMs(audioFiles, player.duration)
+        fun totalDurationMs(): Long = resolveTotalDurationMs(
+            audioFiles,
+            player.duration,
+            aggregateDurationMs
+        )
 
         fun absolutePositionMs(): Long =
             resolveAbsolutePositionMs(audioFiles, currentFileId(), currentFilePositionMs())
 
         fun seekToAbsolutePosition(ms: Long) {
-            val target = resolveSeekTarget(audioFiles, ms)
-            if (target == null) {
+            if (audioFiles.size < 2) {
                 player.seekTo(ms.coerceAtLeast(0L))
-            } else {
+                return
+            }
+            val mediaItemIds = (0 until player.mediaItemCount).map { index ->
+                player.getMediaItemAt(index).mediaId
+            }
+            resolvePlayerSeekTarget(audioFiles, mediaItemIds, ms)?.let { target ->
                 player.seekTo(target.fileIndex, target.positionMs)
             }
         }
@@ -737,7 +802,8 @@ class ReadiumAudioPlaybackService : MediaSessionService() {
             book: BookSummary,
             launchMode: ReaderLaunchMode,
             engine: AudioPlaybackEngine,
-            audioFiles: List<BookFileOption> = emptyList()
+            audioFiles: List<BookFileOption> = emptyList(),
+            aggregateDurationMs: Long? = null
         ): Session {
             closeSession()
             var mediaSession: MediaSession? = null
@@ -750,7 +816,14 @@ class ReadiumAudioPlaybackService : MediaSessionService() {
                     .build()
                 mediaSession = createdSession
                 addSession(createdSession)
-                return Session(book, launchMode, engine, createdSession, audioFiles).also { session ->
+                return Session(
+                    book,
+                    launchMode,
+                    engine,
+                    createdSession,
+                    audioFiles,
+                    aggregateDurationMs
+                ).also { session ->
                     mutableSession.value = session
                 }
             } catch (error: Throwable) {
@@ -1032,7 +1105,8 @@ class ReadiumAudioPlaybackController internal constructor(
         initialPositionMs: Long,
         launchMode: ReaderLaunchMode,
         playWhenReady: Boolean = true,
-        audioFiles: List<BookFileOption> = emptyList()
+        audioFiles: List<BookFileOption> = emptyList(),
+        aggregateDurationMs: Long? = null
     ): ReadiumAudioOpenResult {
         val generation = withContext(Dispatchers.Main.immediate) {
             openGeneration += 1L
@@ -1056,11 +1130,19 @@ class ReadiumAudioPlaybackController internal constructor(
             resetPreparationIfCurrent(generation)
             throw error
         }
+        val useSingleFileEngine = shouldUseSingleFileAudioEngine(file?.isFile == true, audioFiles.size)
+        val preparedAudioFiles = if (useSingleFileEngine) {
+            emptyList()
+        } else {
+            prepareAudiobookPlaylist(audioFiles).files
+        }
         val matchingSession = serviceBinder.session.value?.takeIf { current ->
             current.book.libraryId == book.libraryId &&
                 current.book.id == book.id &&
                 current.book.fileId == book.fileId &&
-                current.launchMode == launchMode
+                current.launchMode == launchMode &&
+                hasSameAudiobookPlaybackManifest(current.audioFiles, preparedAudioFiles) &&
+                current.aggregateDurationMs == aggregateDurationMs
         }
         if (matchingSession != null) {
             return try {
@@ -1084,7 +1166,7 @@ class ReadiumAudioPlaybackController internal constructor(
         val pauseForAudioInterruptions = preferencesStore.read().pauseAudiobookForAudioInterruptions
         val opened = try {
             withTimeoutOrNull(AUDIO_ENGINE_PREPARATION_TIMEOUT_MILLIS) {
-                if (file?.isFile == true) {
+                if (useSingleFileEngine) {
                     openReadiumAudio(
                         application = application,
                         book = book,
@@ -1099,7 +1181,7 @@ class ReadiumAudioPlaybackController internal constructor(
                         book = book,
                         streamUrl = streamUrl,
                         initialPositionMs = initialPositionMs,
-                        audioFiles = audioFiles,
+                        audioFiles = preparedAudioFiles,
                         pauseForAudioInterruptions = pauseForAudioInterruptions,
                         headersProvider = streamingHeadersProvider,
                         recoverAuthentication = streamingAuthenticationRecovery
@@ -1139,7 +1221,13 @@ class ReadiumAudioPlaybackController internal constructor(
                         } else {
                             applyPersistedAudioPlaybackSpeed(opened.engine.player)
                             endReadingSession(serviceBinder.session.value)
-                            val session = serviceBinder.openSession(book, launchMode, opened.engine, audioFiles)
+                            val session = serviceBinder.openSession(
+                                book,
+                                launchMode,
+                                opened.engine,
+                                preparedAudioFiles,
+                                aggregateDurationMs
+                            )
                             if (playWhenReady) opened.engine.player.play()
                             startProgressUpdates(session, recordInitialPlay = playWhenReady)
                             mutablePreparationState.value = AudioPlaybackPreparationState.IDLE

--- a/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
@@ -104,6 +104,108 @@ class AppCoordinatorTest {
     }
 
     @Test
+    fun `opening grouped audiobook passes complete selected format to playback`() = runTest {
+        val selectedBook = book.copy(
+            id = "audio-1",
+            fileId = "mp3-2",
+            title = "Sample Audiobook",
+            format = "mp3",
+            mediaKind = MediaKind.AUDIO,
+            streamUrl = "$serverUrl/api/v1/books/files/mp3-2/serve"
+        )
+        fun option(fileId: String, format: String, filename: String, groupingPath: String) = BookFileOption(
+            book = selectedBook.copy(
+                fileId = fileId,
+                format = format,
+                streamUrl = "$serverUrl/api/v1/books/files/$fileId/serve"
+            ),
+            filename = filename,
+            durationMs = 100_000L,
+            role = "content",
+            groupingPath = groupingPath
+        )
+        val repository = FakeBookOrbitDataSource(
+            bookDetailResult = BookDetailInfo(
+                book = selectedBook,
+                durationSeconds = 801L,
+                availableFiles = listOf(
+                    option("mp3-1", "mp3", "Chapter 01.mp3", "books/sample/CD 1"),
+                    option("mp3-2", "mp3", "Chapter 02.mp3", "books/sample/CD 1"),
+                    option("mp3-3", "mp3", "Chapter 01.mp3", "books/sample/CD 2"),
+                    option("m4b", "m4b", "Sample Audiobook.m4b", "books/sample")
+                )
+            ),
+            buildReaderResult = ReaderState(book = selectedBook, streamUrl = selectedBook.streamUrl)
+        )
+        val coordinator = AppCoordinator(repository, StandardTestDispatcher(testScheduler))
+        var openedState: ReaderState? = null
+        coordinator.setAudioPlaybackOpener { state, _ ->
+            openedState = state
+            true
+        }
+
+        coordinator.openBook(selectedBook)
+        advanceUntilIdle()
+
+        assertEquals(listOf("mp3-1", "mp3-2", "mp3-3"), openedState?.audioFiles?.map { it.fileId })
+        assertEquals(801_000L, openedState?.audioTotalDurationMs)
+    }
+
+    @Test
+    fun `cached grouped audiobook passes complete local-capable playlist to playback`() = runTest {
+        val selectedBook = book.copy(
+            id = "audio-1",
+            fileId = "mp3-2",
+            title = "Downloaded Audiobook",
+            format = "mp3",
+            mediaKind = MediaKind.AUDIO
+        )
+        fun option(fileId: String, filename: String) = BookFileOption(
+            book = selectedBook.copy(
+                fileId = fileId,
+                streamUrl = "https://server.example.test/files/$fileId"
+            ),
+            filename = filename,
+            durationMs = 100_000L,
+            role = "content"
+        )
+        val detail = BookDetailInfo(
+            book = selectedBook,
+            durationSeconds = 200L,
+            availableFiles = listOf(
+                option("mp3-1", "Chapter 01.mp3"),
+                option("mp3-2", "Chapter 02.mp3")
+            )
+        )
+        val repository = FakeBookOrbitDataSource(
+            cachedBrowserState = BrowserState(
+                serverUrl = serverUrl,
+                libraries = listOf(library),
+                selectedLibraryId = library.id,
+                books = listOf(selectedBook),
+                isOfflineSnapshot = true
+            ),
+            cachedBookDetailResult = detail,
+            buildReaderResult = ReaderState(book = selectedBook)
+        )
+        val coordinator = AppCoordinator(repository, StandardTestDispatcher(testScheduler))
+        var openedState: ReaderState? = null
+        coordinator.setAudioPlaybackOpener { state, _ ->
+            openedState = state
+            true
+        }
+
+        coordinator.loadBrowser()
+        advanceUntilIdle()
+        coordinator.openBook(selectedBook)
+        advanceUntilIdle()
+
+        assertEquals(listOf("mp3-1", "mp3-2"), openedState?.audioFiles?.map { it.fileId })
+        assertTrue(openedState?.audioFiles?.all { it.book.streamUrl != null } == true)
+        assertEquals(200_000L, openedState?.audioTotalDurationMs)
+    }
+
+    @Test
     fun `loadBrowser restores persisted interrupted download as failed metadata row`() = runTest {
         val interrupted = DownloadRecord(
             serverUrl = serverUrl,
@@ -2734,6 +2836,7 @@ private class FakeBookOrbitDataSource(
     var sessionStateSequence: List<SessionState> = emptyList(),
     var sessionStateGate: CompletableDeferred<Unit>? = null,
     var cachedBrowserState: BrowserState? = null,
+    var cachedBookDetailResult: BookDetailInfo? = null,
     var restoreActiveReaderLocalOnlyResult: ReaderState? = null,
     var restoreActiveReaderResult: ReaderState? = null,
     var buildReaderResult: ReaderState = ReaderState(
@@ -2892,6 +2995,8 @@ private class FakeBookOrbitDataSource(
     override suspend fun loadInterruptedDownloads(): List<DownloadRecord> = interruptedDownloads
 
     override suspend fun loadBookDetail(book: BookSummary): BookDetailInfo? = bookDetailResult
+
+    override suspend fun loadCachedBookDetail(book: BookSummary): BookDetailInfo? = cachedBookDetailResult
 
     override suspend fun loadReaderProgress(
         book: BookSummary,

--- a/app/src/test/java/com/vangeaux/lagrange/AudiobookTimelineTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AudiobookTimelineTest.kt
@@ -3,6 +3,7 @@ package com.vangeaux.lagrange
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AudiobookTimelineTest {
@@ -68,6 +69,21 @@ class AudiobookTimelineTest {
     }
 
     @Test
+    fun `playbackAudioFiles excludes explicit non-content audio attachments`() {
+        val files = listOf(
+            file("content", 1_000L, role = "content"),
+            file("legacy", 2_000L, role = null),
+            file("metadata", 3_000L, role = "metadata"),
+            file("supplement", 4_000L, role = "supplement")
+        )
+
+        assertEquals(
+            listOf("content", "legacy"),
+            AudiobookTimeline.playbackAudioFiles(files).map { it.fileId }
+        )
+    }
+
+    @Test
     fun `downloadableAudioFiles drops blank and duplicate identities`() {
         val files = listOf(
             file("first", 1_000L),
@@ -126,6 +142,69 @@ class AudiobookTimelineTest {
         )
         assertEquals(listOf(1, 1, 2, 2, 1), groups.map { it.options.size })
         assertEquals(listOf("epub", "pdf", "mp3", "m4a", "m4b"), groups.map { it.options.first().format })
+    }
+
+    @Test
+    fun `selected playback files include ordered content files from selected exact format`() {
+        val options = listOf(
+            file("mp3-1", 100_000L, format = "mp3", filename = "Chapter 01.mp3")
+                .copy(groupingPath = "books/test/Book"),
+            file("mp3-2", 200_000L, format = "mp3", filename = "Chapter 02.mp3")
+                .copy(groupingPath = "books/test/Book"),
+            file("m4b", 300_000L, format = "m4b", filename = "Book.m4b")
+                .copy(groupingPath = "books/test/Book")
+        )
+
+        val selected = AudiobookTimeline.selectedPlaybackAudioFiles(options, "mp3-2")
+
+        assertEquals(listOf("mp3-1", "mp3-2"), selected.map { it.fileId })
+        assertEquals(
+            listOf("m4b"),
+            AudiobookTimeline.selectedPlaybackAudioFiles(options, "m4b").map { it.fileId }
+        )
+    }
+
+    @Test
+    fun `selected local playback files clear remote sources while preserving order`() {
+        val options = listOf(
+            file("mp3-1", 100_000L, format = "mp3").copy(
+                book = file("mp3-1", 100_000L, format = "mp3").book.copy(
+                    streamUrl = "https://server.example.test/mp3-1"
+                )
+            ),
+            file("mp3-2", 200_000L, format = "mp3").copy(
+                book = file("mp3-2", 200_000L, format = "mp3").book.copy(
+                    streamUrl = "https://server.example.test/mp3-2"
+                )
+            )
+        )
+
+        val selected = AudiobookTimeline.selectedLocalPlaybackAudioFiles(options, "mp3-2")
+
+        assertEquals(listOf("mp3-1", "mp3-2"), selected.map { it.fileId })
+        assertTrue(selected.all { it.book.streamUrl == null })
+    }
+
+    @Test
+    fun `selected playback files keep one upstream audiobook across disc paths`() {
+        val options = listOf(
+            file("disc-1-track-1", 100_000L, role = "content", format = "mp3", filename = "01.mp3")
+                .copy(groupingPath = "books/test/Book/CD 1"),
+            file("disc-1-track-2", 200_000L, role = "content", format = "mp3", filename = "02.mp3")
+                .copy(groupingPath = "books/test/Book/CD 1"),
+            file("disc-2-track-1", 300_000L, role = "content", format = "mp3", filename = "01.mp3")
+                .copy(groupingPath = "books/test/Book/CD 2"),
+            file("alternate", 600_000L, role = "content", format = "m4b", filename = "Book.m4b")
+                .copy(groupingPath = "books/test/Book")
+        )
+
+        val selected = AudiobookTimeline.selectedPlaybackAudioFiles(options, "disc-1-track-2")
+
+        assertEquals(
+            listOf("disc-1-track-1", "disc-1-track-2", "disc-2-track-1"),
+            selected.map { it.fileId }
+        )
+        assertEquals(600_000L, AudiobookTimeline.totalDurationMs(selected))
     }
 
     @Test

--- a/app/src/test/java/com/vangeaux/lagrange/BookOrbitPayloadParserTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/BookOrbitPayloadParserTest.kt
@@ -951,15 +951,17 @@ class BookOrbitPayloadParserTest {
                   "audioMetadata": {
                     "chapters": [
                       {"title": "Part One", "startMs": 0},
-                      {"title": "Part Two", "startMs": 300000}
+                      {"title": "Disc Two", "startMs": 301265},
+                      {"title": "Final Part", "startMs": 651265}
                     ]
                   },
                   "files": [
-                    {"id": "mp3-1", "format": "mp3", "role": "primary", "filename": "01.mp3", "absolutePath": "/books/test/Gone Girl/01.mp3", "durationSeconds": 100.765},
-                    {"id": "mp3-2", "format": "mp3", "filename": "02.mp3", "absolutePath": "/books/test/Gone Girl/02.mp3", "durationSeconds": 200.5},
-                    {"id": "mp3-3", "format": "mp3", "filename": "03.mp3", "absolutePath": "/books/test/Gone Girl/03.mp3", "durationSeconds": 50},
-                    {"id": "mp3-4", "format": "mp3", "filename": "04.mp3", "absolutePath": "/books/test/Gone Girl/04.mp3", "durationSeconds": 300},
-                    {"id": "mp3-5", "format": "mp3", "filename": "05.mp3", "absolutePath": "/books/test/Gone Girl/05.mp3", "durationSeconds": 150}
+                    {"id": "mp3-1", "format": "mp3", "role": "content", "filename": "01.mp3", "absolutePath": "/books/test/Gone Girl/CD 1/01.mp3", "durationSeconds": 100.765},
+                    {"id": "mp3-2", "format": "mp3", "role": "content", "filename": "02.mp3", "absolutePath": "/books/test/Gone Girl/CD 1/02.mp3", "durationSeconds": 200.5},
+                    {"id": "mp3-3", "format": "mp3", "role": "content", "filename": "01.mp3", "absolutePath": "/books/test/Gone Girl/CD 2/01.mp3", "durationSeconds": 50},
+                    {"id": "mp3-4", "format": "mp3", "role": "content", "filename": "02.mp3", "absolutePath": "/books/test/Gone Girl/CD 2/02.mp3", "durationSeconds": 300},
+                    {"id": "mp3-5", "format": "mp3", "role": "content", "filename": "03.mp3", "absolutePath": "/books/test/Gone Girl/CD 2/03.mp3", "durationSeconds": 150},
+                    {"id": "m4b-alternate", "format": "m4b", "role": "content", "filename": "Gone Girl.m4b", "absolutePath": "/books/test/Gone Girl/Gone Girl.m4b", "durationSeconds": 801}
                   ]
                 }
             """.trimIndent(),
@@ -968,18 +970,22 @@ class BookOrbitPayloadParserTest {
         )
 
         assertEquals(
-            listOf("mp3-1", "mp3-2", "mp3-3", "mp3-4", "mp3-5"),
+            listOf("mp3-1", "mp3-2", "mp3-3", "mp3-4", "mp3-5", "m4b-alternate"),
             detail.availableFiles.map { it.fileId }
         )
         assertEquals(
-            listOf(100_765L, 200_500L, 50_000L, 300_000L, 150_000L),
+            listOf(100_765L, 200_500L, 50_000L, 300_000L, 150_000L, 801_000L),
             detail.availableFiles.map { it.durationMs }
         )
         assertEquals(
             listOf("/books/test/Gone Girl"),
             detail.availableFiles.mapNotNull { it.groupingPath }.distinct()
         )
-        assertEquals(1, availableFileGroups(detail.availableFiles).size)
+        assertEquals(2, availableFileGroups(detail.availableFiles).size)
+        assertEquals(
+            listOf("mp3-1", "mp3-2", "mp3-3", "mp3-4", "mp3-5"),
+            AudiobookTimeline.selectedPlaybackAudioFiles(detail.availableFiles, "mp3-2").map { it.fileId }
+        )
         assertEquals(801L, detail.durationSeconds)
     }
 

--- a/app/src/test/java/com/vangeaux/lagrange/ReadiumAudioPlaybackTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/ReadiumAudioPlaybackTest.kt
@@ -83,6 +83,71 @@ class ReadiumAudioPlaybackTest {
     }
 
     @Test
+    fun preparedPlaylistUsesTheExactSameFilesForMediaItemsAndTimelineSeeking() {
+        val files = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("missing-source", null, durationMs = 50_000L),
+            file("f2", "https://server/stream/f2", durationMs = 200_000L)
+        )
+
+        val playlist = prepareAudiobookPlaylist(files)
+        val target = resolveSeekTarget(playlist.files, 100_500L)
+
+        assertEquals(listOf("f1", "f2"), playlist.specs.map { it.fileId })
+        assertEquals(listOf("f1", "f2"), playlist.files.map { it.fileId })
+        assertEquals(1, target?.fileIndex)
+        assertEquals("f2", target?.fileId)
+        assertEquals(500L, target?.positionMs)
+    }
+
+    @Test
+    fun sameBookSessionReuseRequiresTheSameOrderedPhysicalFileManifest() {
+        val existing = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L)
+        )
+        val corrected = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("f2", "https://server/stream/f2", durationMs = 200_000L)
+        )
+
+        assertEquals(false, hasSameAudiobookPlaybackManifest(existing, corrected))
+        assertEquals(true, hasSameAudiobookPlaybackManifest(corrected, corrected))
+        assertEquals(false, hasSameAudiobookPlaybackManifest(corrected, corrected.reversed()))
+    }
+
+    @Test
+    fun restorationSelectsTheSavedLaterPhysicalFileByStableId() {
+        val mediaItemIds = listOf("f1", "f2", "f3")
+
+        assertEquals(2, resolveInitialAudiobookMediaItemIndex(mediaItemIds, "f3"))
+        assertEquals(0, resolveInitialAudiobookMediaItemIndex(mediaItemIds, "unknown"))
+    }
+
+    @Test
+    fun serverAggregateDurationIsAuthoritativeForMultipartSeekbar() {
+        val files = listOf(
+            file("f1", "https://server/stream/f1", durationMs = null),
+            file("f2", "https://server/stream/f2", durationMs = null)
+        )
+
+        assertEquals(600_000L, resolveTotalDurationMs(files, 100_000L, 600_000L))
+    }
+
+    @Test
+    fun partiallyDownloadedMultipartAudiobookStillUsesThePlaylistEngine() {
+        assertEquals(false, shouldUseSingleFileAudioEngine(true, 3))
+        assertEquals(true, shouldUseSingleFileAudioEngine(true, 1))
+        assertEquals(false, shouldUseSingleFileAudioEngine(false, 3))
+    }
+
+    @Test
+    fun preparedLocalPlaylistUsesMedia3EvenWhenOnlyOneMultipartTrackIsAvailable() {
+        assertEquals(true, shouldUsePlaylistMedia3Audio(1))
+        assertEquals(true, shouldUsePlaylistMedia3Audio(2))
+        assertEquals(false, shouldUsePlaylistMedia3Audio(0))
+    }
+
+    @Test
     fun resolveAbsolutePositionMsMapsFileRelativePositionAcrossTracks() {
         val files = listOf(
             file("f1", "https://server/stream/f1", durationMs = 100_000L),
@@ -109,6 +174,63 @@ class ReadiumAudioPlaybackTest {
     fun resolveSeekTargetMapsAbsolutePositionToTrackAndOffset() {
         val files = listOf(
             file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("f2", "https://server/stream/f2", durationMs = 200_000L)
+        )
+
+        val target = resolveSeekTarget(files, 100_500L)
+
+        assertEquals(1, target?.fileIndex)
+        assertEquals("f2", target?.fileId)
+        assertEquals(500L, target?.positionMs)
+    }
+
+    @Test
+    fun playerSeekTargetResolvesTheFinalMedia3IndexByStableFileId() {
+        val files = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("f2", "https://server/stream/f2", durationMs = 200_000L)
+        )
+
+        val target = resolvePlayerSeekTarget(files, listOf("f2", "f1"), 100_500L)
+
+        assertEquals(0, target?.fileIndex)
+        assertEquals("f2", target?.fileId)
+        assertEquals(500L, target?.positionMs)
+    }
+
+    @Test
+    fun playerSeekTargetsUseOneThreeFileBookTimelineAcrossBothBoundaries() {
+        val files = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("f2", "https://server/stream/f2", durationMs = 200_000L),
+            file("f3", "https://server/stream/f3", durationMs = 300_000L)
+        )
+        val mediaItemIds = listOf("f1", "f2", "f3")
+
+        val endOfFirst = resolvePlayerSeekTarget(files, mediaItemIds, 99_999L)
+        val startOfSecond = resolvePlayerSeekTarget(files, mediaItemIds, 100_000L)
+        val chapterInSecond = resolvePlayerSeekTarget(files, mediaItemIds, 150_000L)
+        val startOfThird = resolvePlayerSeekTarget(files, mediaItemIds, 300_000L)
+        val chapterInThird = resolvePlayerSeekTarget(files, mediaItemIds, 450_000L)
+
+        assertEquals(0, endOfFirst?.fileIndex)
+        assertEquals(99_999L, endOfFirst?.positionMs)
+        assertEquals(1, startOfSecond?.fileIndex)
+        assertEquals(0L, startOfSecond?.positionMs)
+        assertEquals(1, chapterInSecond?.fileIndex)
+        assertEquals(50_000L, chapterInSecond?.positionMs)
+        assertEquals(2, startOfThird?.fileIndex)
+        assertEquals(0L, startOfThird?.positionMs)
+        assertEquals(2, chapterInThird?.fileIndex)
+        assertEquals(150_000L, chapterInThird?.positionMs)
+    }
+
+    @Test
+    fun resolveSeekTargetUsesTheSameTrackSetAsTheMedia3Playlist() {
+        val files = listOf(
+            file("f1", "https://server/stream/f1", durationMs = 100_000L),
+            file("supplement", "https://server/stream/supplement", durationMs = 50_000L)
+                .copy(role = "supplement"),
             file("f2", "https://server/stream/f2", durationMs = 200_000L)
         )
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,6 +90,14 @@ Open the grouped format picker and verify ordinary tap still selects the whole g
 
 At the current checkpoint, focused issue #156 automated tests and the full JVM suite have passed. The final Gradle/lint/APK gate has passed with 706 JVM tests and 0 failures/errors/skips; the user confirmed the grouped inspector download-state and per-file deletion behavior works on-device. Android-test compilation or APK assembly does not replace that device validation.
 
+### Multipart audiobook timeline and local playback (issue #161)
+
+On a connected device or emulator, open a grouped audiobook with multiple physical files in one exact format. Verify the player receives the complete server-ordered content manifest, excludes alternate formats and supplements, and displays the server-provided aggregate duration even when only some files are downloaded locally. Chapter taps, seekbar jumps, fast-forward/skip controls, and automatic transitions must use the same book-global timeline and stable physical file IDs.
+
+With only the first physical file downloaded, open the audiobook online and verify the downloaded item uses its local path while the missing item can use its authenticated server stream. Enable Airplane Mode and reopen the fully or partially downloaded audiobook from Local books. Verify remote URLs are not attempted, valid local files are opened through the Media3 playlist even when only one local item is available, and an audiobook with no valid local item reports a local-availability error instead of closing silently. Resume from a later downloaded file and verify its physical file ID and in-file position are restored.
+
+Automated coverage includes server-authoritative aggregate duration, exact-format ordered membership, cached grouped-file propagation, stable Media3 IDs, one-item local playlist handling, scheme-aware local/HTTP Media3 data sources, cross-file seeking, transitions, stale-manifest replacement, and later-file restoration. The user confirmed the downloaded grouped-audiobook player opens and works; no assistant-side connected-device instrumentation was available.
+
 ### Local-open fallback
 
 On a connected device or emulator, complete a download, immediately enable Airplane Mode, open Local books, and tap the downloaded book before refreshing or restarting the app. Repeat for EPUB, PDF, CBZ/CBR/CB7, and audiobook files. Each valid completed local copy should open after the failed online/detail attempt. Also verify that an offline book with no local copy retains the normal network error, an invalid local file reports an integrity/preparation error, and a corrupt comic archive reports its extraction error rather than the network failure. Repeat one healthy online open to confirm the normal authoritative path remains preferred.
@@ -249,11 +257,15 @@ Disable the setting and verify the keys adjust system volume normally. With an a
 
 Automated verification for issue #95 passed 580 JVM tests with 0 failures, errors, or skips, plus main/unit/Android-test compilation, lint, debug assembly, and Android-test assembly. No connected device was available, so the checks above remain pending physical-device validation.
 
-### Multi-file streamed MP3 audiobook playback (issue #36)
+### Multipart audiobook chapter/seek and manifest regression (issues #36 and #161)
 
-The implementation and live-device validation are complete. The user confirmed that a BookOrbit audiobook composed of ordered MP3 files plays as one continuous streamed audiobook. Multi-file streamed MP3 support is included in the 1.5.0 release scope.
+On a connected device or emulator, open a multipart audiobook whose detail payload contains ordered content files in one exact audio format, including files whose `groupingPath` values differ. Select that format and verify playback prepares one playlist containing every ordered same-format content file for the selected edition. `groupingPath` must not split the playlist; an alternate audio format, a non-content audio attachment, and metadata/supplement files must not enter it or change its order. Reopen or refresh the detail and confirm the selected edition still uses the same ordered stable file IDs.
 
-For regression testing, verify chapter selection and automatic advancement across at least two file boundaries; compact-player elapsed/remaining time and slider position across the complete audiobook; ±10/30-second seeks around a boundary; and online relaunch/resume in a later file using the active file ID and in-file position. Recheck a single-file M4B and downloaded/local audio. Multi-file offline download/storage remains out of scope.
+In both the compact and full player, tap a chapter and move the overall seekbar to positions before and after at least one physical-file boundary. Verify each action reaches the corresponding book-global position, playback continues, and the displayed elapsed/remaining duration and progress reflect the complete prepared timeline. Also verify automatic advancement across at least two boundaries and ±10/30-second seeks around a boundary. Relaunch online at a later file and verify resume uses that file's stable ID and in-file position. Recheck a single-file M4B and downloaded/local audio. Multi-file offline download/storage lifecycle is covered by issue #156; this section verifies playback from those local files.
+
+Change the available-file manifest for the same book (for example, add or remove a content file or change its order), then reopen playback and verify the stale same-book session is not reused: the new ordered file-ID manifest is prepared and global seeks map against the new timeline.
+
+Focused JVM tests and the full Gradle/lint/APK gate for issue #161 pass. Physical-device validation remains outstanding; compiled Android-test sources do not constitute executed instrumentation.
 
 ### Authentication and OIDC
 


### PR DESCRIPTION
## Summary
- Preserve the complete ordered same-format audiobook manifest and server-authoritative aggregate duration.
- Route downloaded multipart playback through a scheme-aware Media3 playlist, including one valid local item, while retaining online streaming for missing files.
- Fix chapter, seekbar, skip, transition, progress, and restoration mapping by stable physical file ID.

## Verification
- 721 JVM tests passed, 0 failures, 0 errors, 0 skipped.
- Debug and Android-test Kotlin compilation passed.
- Lint passed.
- Debug and Android-test APK assembly passed.
- `git -c core.whitespace=cr-at-eol diff --check` passed.
- User confirmed the downloaded grouped-audiobook player works on-device.
- Assistant-side connected-device instrumentation was unavailable.

APK: `Lagrange-debug-202609111054.apk`
SHA-256: `19b5527a6da61357b377db786f4a4ed0892de2484f1c071fe0609bf264f517e3`

Closes #161