### PR TITLE
fix: distinguish queued downloads in Local books

### DIFF
--- a/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
+++ b/app/src/main/java/com/vangeaux/lagrange/AppCoordinator.kt
@@ -41,10 +41,12 @@ internal fun recoveredDownloadFilename(
 
 internal fun BrowserState.withQueuedDownloads(downloads: List<ScheduledDownload>): BrowserState {
     val fileIds = downloads.mapTo(linkedSetOf()) { it.fileId }
-    val activeFileId = fileIds.firstOrNull()
+    val hasActiveTransfer = downloadingFileIds.isNotEmpty()
+    val activeFileId = fileIds.firstOrNull().takeUnless { hasActiveTransfer }
+    val queuedFileIds = if (hasActiveTransfer) fileIds else fileIds.drop(1)
     return copy(
         downloadingFileIds = downloadingFileIds + listOfNotNull(activeFileId),
-        queuedDownloadFileIds = queuedDownloadFileIds + fileIds.drop(1),
+        queuedDownloadFileIds = queuedDownloadFileIds + queuedFileIds,
         downloadProgressByFileId = downloadProgressByFileId - fileIds,
         failedDownloadFileIds = failedDownloadFileIds - fileIds,
         permissionDeniedDownloadFileIds = permissionDeniedDownloadFileIds - fileIds,

--- a/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
+++ b/app/src/test/java/com/vangeaux/lagrange/AppCoordinatorTest.kt
@@ -580,6 +580,26 @@ class AppCoordinatorTest {
     }
 
     @Test
+    fun `queued batch preserves existing active file and queues every new file in order`() {
+        val first = BookSummary("library", "book-1", "file-1", "Part 1")
+        val second = BookSummary("library", "book-1", "file-2", "Part 2")
+        val state = BrowserState(
+            serverUrl = serverUrl,
+            libraries = emptyList(),
+            selectedLibraryId = null,
+            books = emptyList(),
+            downloadingFileIds = setOf("file-active")
+        )
+
+        val projected = state.withQueuedDownloads(
+            listOf(ScheduledDownload(first, "file-1"), ScheduledDownload(second, "file-2"))
+        )
+
+        assertEquals(setOf("file-active"), projected.downloadingFileIds)
+        assertEquals(listOf("file-1", "file-2"), projected.queuedDownloadFileIds.toList())
+    }
+
+    @Test
     fun `download transfer rows prefer restored attempt metadata over unknown active files`() {
         val state = BrowserState(
             serverUrl = serverUrl,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,7 +64,7 @@ On a connected device or emulator, verify from Home, Library, Search, Series, Au
 - failed transfers show `Retry` and `Clear`;
 - downloaded books show `Delete local`;
 - Local books shows active/failed Downloads rows only when needed;
-- Local books Downloads can be expanded and collapsed; expanded rows scroll inside a body no taller than half the available screen, long book titles remain one line and marquee, each row shows the active physical filename beneath the shared title, the grouped logical Local book card shows the active sibling filename when it differs from the representative file, refresh the catalog and verify queued sibling rows survive, reload completed Local books and verify their physical filenames remain, and active-row `Cancel` is beside its progress bar;
+|- Local books Downloads can be expanded and collapsed; expanded rows scroll inside a body no taller than half the available screen, long book titles remain one line and marquee, each row shows the active physical filename beneath the shared title, the grouped logical Local book card shows the active sibling filename when it differs from the representative file, refresh the catalog and verify queued sibling rows survive, verify only the currently transferring row is labeled `Downloading` while queued rows are labeled `Waiting`, including when a second batch is added during an active transfer, reload completed Local books and verify their physical filenames remain, and active-row `Cancel` is beside its progress bar;
 - `Clear` and `Clear all` remove failed state without cancelling active transfers;
 - force-closing during a download restores a failed row with `Retry` and `Clear`;
 - a failed first download stays out of Local books;


### PR DESCRIPTION
## Summary
- Keep only the currently transferring file in the active download state.
- Show later FIFO files as waiting instead of downloading in Local books.
- Add regression coverage for adding a batch while another transfer is active.
- Update the Local books manual test procedure.

## Verification
- Focused `AppCoordinatorTest` passed.
- Full JVM suite: 723 tests, 0 failures, 0 errors, 0 skipped.
- Main, JVM-test, and Android-test Kotlin compilation passed.
- `lintDebug` passed with existing warnings/information findings.
- Debug and Android-test APK assembly passed.
- No connected device was available for assistant-side instrumentation; the user confirmed the behavior works on-device.
- Handoff APK: `app/build/outputs/apk/debug/Lagrange-debug-202609111323.apk`.

Closes #165